### PR TITLE
Initial support for Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/py/build
+/py/dist
+/py/kiwi.egg-info

--- a/py/constraint.cpp
+++ b/py/constraint.cpp
@@ -70,7 +70,7 @@ Constraint_dealloc( Constraint* self )
     PyObject_GC_UnTrack( self );
     Constraint_clear( self );
     self->constraint.~Constraint();
-    self->ob_type->tp_free( pyobject_cast( self ) );
+    Py_TYPE( self )->tp_free( pyobject_cast( self ) );
 }
 
 
@@ -102,7 +102,11 @@ Constraint_repr( Constraint* self )
             break;
     }
     stream << " | strength = " << self->constraint.strength();
-    return PyString_FromString( stream.str().c_str() );
+    #if PY_MAJOR_VERSION >= 3
+        return PyUnicode_FromString( stream.str().c_str() );
+    #else
+        return PyString_FromString( stream.str().c_str() );
+    #endif
 }
 
 
@@ -120,13 +124,25 @@ Constraint_op( Constraint* self )
     switch( self->constraint.op() )
     {
         case kiwi::OP_EQ:
-            res = PyString_FromString( "==" );
+            #if PY_MAJOR_VERSION >= 3
+                res = PyUnicode_FromString( "==" );
+            #else 
+                res = PyString_FromString( "==" );
+            #endif
             break;
         case kiwi::OP_LE:
-            res = PyString_FromString( "<=" );
+            #if PY_MAJOR_VERSION >= 3
+                res = PyUnicode_FromString( "<=" );
+            #else
+                res = PyString_FromString( "<=" );
+            #endif
             break;
         case kiwi::OP_GE:
-            res = PyString_FromString( ">=" );
+            #if PY_MAJOR_VERSION >= 3
+                res = PyUnicode_FromString( ">=" );
+            #else
+                res = PyString_FromString( ">=" );
+            #endif
             break;
     }
     return res;
@@ -176,30 +192,42 @@ Constraint_as_number = {
     0,                          /* nb_add */
     0,                          /* nb_subtract */
     0,                          /* nb_multiply */
+    #if PY_MAJOR_VERSION < 3
     0,                          /* nb_divide */
+    #endif
     0,                          /* nb_remainder */
     0,                          /* nb_divmod */
     0,                          /* nb_power */
     0,                          /* nb_negative */
     0,                          /* nb_positive */
     0,                          /* nb_absolute */
+    #if PY_MAJOR_VERSION > 3
+    0,                          /* nb_bool */
+    #else
     0,                          /* nb_nonzero */
+    #endif
     0,                          /* nb_invert */
     0,                          /* nb_lshift */
     0,                          /* nb_rshift */
     0,                          /* nb_and */
     0,                          /* nb_xor */
     (binaryfunc)Constraint_or,  /* nb_or */
+    #if PY_MAJOR_VERSION < 3
     0,                          /* nb_coerce */
+    #endif
     0,                          /* nb_int */
     0,                          /* nb_long */
     0,                          /* nb_float */
+    #if PY_MAJOR_VERSION < 3
     0,                          /* nb_oct */
     0,                          /* nb_hex */
+    #endif
     0,                          /* nb_inplace_add */
     0,                          /* nb_inplace_subtract */
     0,                          /* nb_inplace_multiply */
+    #if PY_MAJOR_VERSION < 3
     0,                          /* nb_inplace_divide */
+    #endif
     0,                          /* nb_inplace_remainder */
     0,                          /* nb_inplace_power */
     0,                          /* nb_inplace_lshift */
@@ -207,17 +235,18 @@ Constraint_as_number = {
     0,                          /* nb_inplace_and */
     0,                          /* nb_inplace_xor */
     0,                          /* nb_inplace_or */
-    0,                          /* nb_floor_divide */
-    0,                          /* nb_true_divide */
+    (binaryfunc)0,              /* nb_floor_divide */
+    (binaryfunc)0,              /* nb_true_divide */
     0,                          /* nb_inplace_floor_divide */
     0,                          /* nb_inplace_true_divide */
-    0,                          /* nb_index */
+    #if PY_VERSION_HEX >= 0x02050000
+    (unaryfunc)0,                          /* nb_index */
+    #endif
 };
 
 
 PyTypeObject Constraint_Type = {
-    PyObject_HEAD_INIT( 0 )
-    0,                                      /* ob_size */
+    PyVarObject_HEAD_INIT( &PyType_Type, 0 )    
     "pykiwi.Constraint",                    /* tp_name */
     sizeof( Constraint ),                   /* tp_basicsize */
     0,                                      /* tp_itemsize */
@@ -236,7 +265,11 @@ PyTypeObject Constraint_Type = {
     (getattrofunc)0,                        /* tp_getattro */
     (setattrofunc)0,                        /* tp_setattro */
     (PyBufferProcs*)0,                      /* tp_as_buffer */
+    #if PY_MAJOR_VERSION >= 3
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC|Py_TPFLAGS_BASETYPE, /* tp_flags */
+    #else
     Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES, /* tp_flags */
+    #endif
     0,                                      /* Documentation string */
     (traverseproc)Constraint_traverse,      /* tp_traverse */
     (inquiry)Constraint_clear,              /* tp_clear */

--- a/py/expression.cpp
+++ b/py/expression.cpp
@@ -69,7 +69,7 @@ Expression_dealloc( Expression* self )
 {
     PyObject_GC_UnTrack( self );
     Expression_clear( self );
-    self->ob_type->tp_free( pyobject_cast( self ) );
+    Py_TYPE( self )->tp_free( pyobject_cast( self ) );
 }
 
 
@@ -87,7 +87,11 @@ Expression_repr( Expression* self )
         stream << " + ";
     }
     stream << self->constant;
-    return PyString_FromString( stream.str().c_str() );
+    #if PY_MAJOR_VERSION >= 3
+        return PyUnicode_FromString( stream.str().c_str() );
+    #else
+        return PyString_FromString( stream.str().c_str() );
+    #endif
 }
 
 
@@ -125,12 +129,13 @@ Expression_mul( PyObject* first, PyObject* second )
     return BinaryInvoke<BinaryMul, Expression>()( first, second );
 }
 
-
-static PyObject*
-Expression_div( PyObject* first, PyObject* second )
-{
-    return BinaryInvoke<BinaryDiv, Expression>()( first, second );
-}
+#if PY_MAJOR_VERSION < 3
+    static PyObject*
+    Expression_div( PyObject* first, PyObject* second )
+    {
+        return BinaryInvoke<BinaryDiv, Expression>()( first, second );
+    }
+#endif
 
 
 static PyObject*
@@ -181,48 +186,60 @@ Expression_as_number = {
     (binaryfunc)Expression_add, /* nb_add */
     (binaryfunc)Expression_sub, /* nb_subtract */
     (binaryfunc)Expression_mul, /* nb_multiply */
+    #if PY_MAJOR_VERSION < 3
     (binaryfunc)Expression_div, /* nb_divide */
+    #endif
     0,                          /* nb_remainder */
     0,                          /* nb_divmod */
     0,                          /* nb_power */
     (unaryfunc)Expression_neg,  /* nb_negative */
     0,                          /* nb_positive */
     0,                          /* nb_absolute */
+    #if PY_MAJOR_VERSION > 3
+    0,                          /* nb_bool */
+    #else
     0,                          /* nb_nonzero */
+    #endif
     0,                          /* nb_invert */
     0,                          /* nb_lshift */
     0,                          /* nb_rshift */
     0,                          /* nb_and */
     0,                          /* nb_xor */
-    0,                          /* nb_or */
+    (binaryfunc)0,              /* nb_or */
+    #if PY_MAJOR_VERSION < 3
     0,                          /* nb_coerce */
+    #endif
     0,                          /* nb_int */
     0,                          /* nb_long */
     0,                          /* nb_float */
+    #if PY_MAJOR_VERSION < 3
     0,                          /* nb_oct */
     0,                          /* nb_hex */
+    #endif
     0,                          /* nb_inplace_add */
     0,                          /* nb_inplace_subtract */
     0,                          /* nb_inplace_multiply */
+    #if PY_MAJOR_VERSION < 3
     0,                          /* nb_inplace_divide */
-    0,                          /* nb_inplace_remainder */
+    #endif
     0,                          /* nb_inplace_power */
     0,                          /* nb_inplace_lshift */
     0,                          /* nb_inplace_rshift */
     0,                          /* nb_inplace_and */
     0,                          /* nb_inplace_xor */
     0,                          /* nb_inplace_or */
-    0,                          /* nb_floor_divide */
-    0,                          /* nb_true_divide */
+    (binaryfunc)0,              /* nb_floor_divide */
+    (binaryfunc)0,              /* nb_true_divide */
     0,                          /* nb_inplace_floor_divide */
     0,                          /* nb_inplace_true_divide */
+    #if PY_VERSION_HEX >= 0x02050000
     0,                          /* nb_index */
+    #endif
 };
 
 
 PyTypeObject Expression_Type = {
-    PyObject_HEAD_INIT( 0 )
-    0,                                      /* ob_size */
+    PyVarObject_HEAD_INIT( &PyType_Type, 0 )
     "pykiwi.Expression",                    /* tp_name */
     sizeof( Expression ),                   /* tp_basicsize */
     0,                                      /* tp_itemsize */
@@ -241,7 +258,11 @@ PyTypeObject Expression_Type = {
     (getattrofunc)0,                        /* tp_getattro */
     (setattrofunc)0,                        /* tp_setattro */
     (PyBufferProcs*)0,                      /* tp_as_buffer */
+    #if PY_MAJOR_VERSION >= 3
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC|Py_TPFLAGS_BASETYPE,
+    #else
     Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES, /* tp_flags */
+    #endif
     0,                                      /* Documentation string */
     (traverseproc)Expression_traverse,      /* tp_traverse */
     (inquiry)Expression_clear,              /* tp_clear */

--- a/py/pythonhelpers.h
+++ b/py/pythonhelpers.h
@@ -16,9 +16,16 @@
     return Py_INCREF(Py_NotImplemented), Py_NotImplemented
 #endif
 
+#ifndef cmpfunc
+#define cmpfunc int
+#endif
 
 #define pyobject_cast( o ) ( reinterpret_cast<PyObject*>( o ) )
 #define pytype_cast( o ) ( reinterpret_cast<PyTypeObject*>( o ) )
+
+struct module_state {
+    PyObject *error;
+};
 
 
 namespace PythonHelpers
@@ -688,6 +695,10 @@ public:
 
 };
 
+/* TODO - is there a better way than this?? */
+#ifndef PyMethod_GET_CLASS
+#define PyMethod_GET_CLASS(m) (PyObject*)Py_TYPE(PyMethod_GET_SELF(m))
+#endif
 
 /*-----------------------------------------------------------------------------
 | Method Ptr

--- a/py/setup.py
+++ b/py/setup.py
@@ -6,7 +6,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-------------------------------------------------------------------------------
 from setuptools import setup, Extension
-import sipdistutils
+#import sipdistutils
 
 
 ext_modules = [
@@ -25,8 +25,8 @@ ext_modules = [
 
 
 setup(
-    name='atom',
-    version='0.3.2',
+    name='kiwi',
+    version='0.1.1',
     author='The Nucleic Development Team',
     author_email='sccolbert@gmail.com',
     url='https://github.com/nucleic/kiwi',

--- a/py/solver.cpp
+++ b/py/solver.cpp
@@ -33,7 +33,7 @@ static void
 Solver_dealloc( Solver* self )
 {
 	self->solver.~Solver();
-	self->ob_type->tp_free( pyobject_cast( self ) );
+	Py_TYPE( self )->tp_free( pyobject_cast( self ) );
 }
 
 
@@ -225,8 +225,7 @@ Solver_methods[] = {
 
 
 PyTypeObject Solver_Type = {
-	PyObject_HEAD_INIT( 0 )
-	0,                                      /* ob_size */
+	PyVarObject_HEAD_INIT( &PyType_Type, 0 )
 	"pykiwi.Solver",                        /* tp_name */
 	sizeof( Solver ),                       /* tp_basicsize */
 	0,                                      /* tp_itemsize */

--- a/py/symbolics.h
+++ b/py/symbolics.h
@@ -61,8 +61,10 @@ struct BinaryInvoke
 			return Invk()( primary, reinterpret_cast<Variable*>( secondary ) );
 		if( PyFloat_Check( secondary ) )
 			return Invk()( primary, PyFloat_AS_DOUBLE( secondary ) );
-		if( PyInt_Check( secondary ) )
-			return Invk()( primary, double( PyInt_AS_LONG( secondary ) ) );
+		#if PY_MAJOR_VERSION < 3
+			if( PyInt_Check( secondary ) )
+				return Invk()( primary, double( PyInt_AS_LONG( secondary ) ) );
+		#endif
 		if( PyLong_Check( secondary ) )
 		{
 			double v = PyLong_AsDouble( secondary );

--- a/py/util.h
+++ b/py/util.h
@@ -22,11 +22,13 @@ convert_to_double( PyObject* obj, double& out )
         out = PyFloat_AS_DOUBLE( obj );
         return true;
     }
-    if( PyInt_Check( obj ) )
-    {
-        out = double( PyInt_AsLong( obj ) );
-        return true;
-    }
+    #if PY_MAJOR_VERSION < 3
+        if( PyInt_Check( obj ) )
+        {
+            out = double( PyInt_AsLong( obj ) );
+            return true;
+        }
+    #endif
     if( PyLong_Check( obj ) )
     {
         out = PyLong_AsDouble( obj );
@@ -42,9 +44,15 @@ convert_to_double( PyObject* obj, double& out )
 inline bool
 convert_to_strength( PyObject* value, double& out )
 {
-    if( PyString_Check( value ) )
-    {
-        std::string str( PyString_AS_STRING( value ) );
+    #if PY_MAJOR_VERSION >= 3
+        if( PyUnicode_Check( value ) )
+        {
+            std::string str( _PyUnicode_AsString( value ) );
+    #else
+        if( PyString_Check( value ) )
+        {
+            std::string str( PyString_AS_STRING( value ) );
+    #endif
         if( str == "required" )
             out = kiwi::strength::required;
         else if( str == "strong" )
@@ -74,12 +82,21 @@ convert_to_strength( PyObject* value, double& out )
 inline bool
 convert_to_relational_op( PyObject* value, kiwi::RelationalOperator& out )
 {
-    if( !PyString_Check( value ) )
-    {
-        PythonHelpers::py_expected_type_fail( value, "str" );
-        return false;
-    }
-    std::string str( PyString_AS_STRING( value ) );
+    #if PY_MAJOR_VERSION >= 3
+        if( !PyUnicode_Check( value ) )
+        {
+            PythonHelpers::py_expected_type_fail( value, "unicode" );
+            return false; 
+        }
+        std::string str( _PyUnicode_AsString( value ) );
+    #else
+        if( !PyString_Check( value ) )
+        {
+            PythonHelpers::py_expected_type_fail( value, "str" );
+            return false;
+        }
+        std::string str( PyString_AS_STRING( value ) );
+    #endif
     if( str == "==" )
         out = kiwi::OP_EQ;
     else if( str == "<=" )

--- a/py/variable.cpp
+++ b/py/variable.cpp
@@ -19,19 +19,33 @@ using namespace PythonHelpers;
 static PyObject*
 Variable_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
 {
-	static const char *kwlist[] = { "name", "context", 0 };
-	PyObject* name;
+	static const char *kwlist[] = { "name", "context", 0 };	
 	PyObject* context = 0;
-	if( !PyArg_ParseTupleAndKeywords(
-		args, kwargs, "S|O:__new__", const_cast<char**>( kwlist ),
-		&name, &context ) )
-		return 0;
+
+	#if PY_MAJOR_VERSION >= 3
+		const char* name;
+		int length;
+		if( !PyArg_ParseTupleAndKeywords(
+			args, kwargs, "s#|O:__new__", const_cast<char**>( kwlist ),
+			&name, &length, &context ) )
+			return 0;
+	#else
+		PyObject* name;
+		if( !PyArg_ParseTupleAndKeywords(
+			args, kwargs, "S|O:__new__", const_cast<char**>( kwlist ),
+			&name, &context ) )
+			return 0;
+	#endif
 	PyObject* pyvar = PyType_GenericNew( type, args, kwargs );
 	if( !pyvar )
 		return 0;
 	Variable* self = reinterpret_cast<Variable*>( pyvar );
 	self->context = xnewref( context );
-	new( &self->variable ) kiwi::Variable( PyString_AS_STRING( name ) );
+	#if PY_MAJOR_VERSION >= 3
+		new( &self->variable ) kiwi::Variable( name );
+	#else
+		new( &self->variable ) kiwi::Variable( PyString_AS_STRING( name ) );
+	#endif
 	return pyvar;
 }
 
@@ -57,30 +71,44 @@ Variable_dealloc( Variable* self )
 	PyObject_GC_UnTrack( self );
 	Variable_clear( self );
 	self->variable.~Variable();
-	self->ob_type->tp_free( pyobject_cast( self ) );
+	Py_TYPE( self )->tp_free( pyobject_cast( self ) );
 }
 
 
 static PyObject*
 Variable_repr( Variable* self )
 {
-	return PyString_FromString( self->variable.name().c_str() );
+	#if PY_MAJOR_VERSION >= 3
+		return PyUnicode_FromString( self->variable.name().c_str() );
+	#else
+		return PyString_FromString( self->variable.name().c_str() );
+	#endif
 }
 
 
 static PyObject*
 Variable_name( Variable* self )
 {
-	return PyString_FromString( self->variable.name().c_str() );
+	#if PY_MAJOR_VERSION >= 3
+		return PyUnicode_FromString( self->variable.name().c_str() );
+	#else
+		return PyString_FromString( self->variable.name().c_str() );
+	#endif
 }
 
 
 static PyObject*
 Variable_setName( Variable* self, PyObject* pystr )
 {
-	if( !PyString_Check( pystr ) )
-		return py_expected_type_fail( pystr, "str" );
-	self->variable.setName( PyString_AS_STRING( pystr ) );
+	#if PY_MAJOR_VERSION >= 3
+		if( !PyUnicode_Check( pystr ) )
+			return py_expected_type_fail( pystr, "unicode" );
+		self->variable.setName( _PyUnicode_AsString( pystr ) );
+	#else
+		if( !PyString_Check( pystr ) )
+			return py_expected_type_fail( pystr, "str" );
+		self->variable.setName( PyString_AS_STRING( pystr ) );
+	#endif
 	Py_RETURN_NONE;
 }
 
@@ -196,30 +224,42 @@ Variable_as_number = {
 	(binaryfunc)Variable_add,   /* nb_add */
 	(binaryfunc)Variable_sub,   /* nb_subtract */
 	(binaryfunc)Variable_mul,   /* nb_multiply */
+	#if PY_MAJOR_VERSION < 3
 	(binaryfunc)Variable_div,   /* nb_divide */
+	#endif
 	0,                          /* nb_remainder */
 	0,                          /* nb_divmod */
 	0,                          /* nb_power */
 	(unaryfunc)Variable_neg,    /* nb_negative */
 	0,                          /* nb_positive */
 	0,                          /* nb_absolute */
+	#if PY_MAJOR_VERSION > 3
+	0, 							/* nb_bool */
+	#else
 	0,                          /* nb_nonzero */
+	#endif
 	0,                          /* nb_invert */
 	0,                          /* nb_lshift */
 	0,                          /* nb_rshift */
 	0,                          /* nb_and */
 	0,                          /* nb_xor */
-	0,                          /* nb_or */
+	(binaryfunc)0,              /* nb_or */
+	#if PY_MAJOR_VERSION < 3
 	0,                          /* nb_coerce */
+	#endif
 	0,                          /* nb_int */
 	0,                          /* nb_long */
 	0,                          /* nb_float */
+	#if PY_MAJOR_VERSION < 3
 	0,                          /* nb_oct */
 	0,                          /* nb_hex */
+	#endif
 	0,                          /* nb_inplace_add */
 	0,                          /* nb_inplace_subtract */
 	0,                          /* nb_inplace_multiply */
+	#if PY_MAJOR_VERSION < 3 
 	0,                          /* nb_inplace_divide */
+	#endif
 	0,                          /* nb_inplace_remainder */
 	0,                          /* nb_inplace_power */
 	0,                          /* nb_inplace_lshift */
@@ -227,17 +267,18 @@ Variable_as_number = {
 	0,                          /* nb_inplace_and */
 	0,                          /* nb_inplace_xor */
 	0,                          /* nb_inplace_or */
-	0,                          /* nb_floor_divide */
-	0,                          /* nb_true_divide */
+	(binaryfunc)0,              /* nb_floor_divide */
+	(binaryfunc)0,              /* nb_true_divide */
 	0,                          /* nb_inplace_floor_divide */
 	0,                          /* nb_inplace_true_divide */
-	0,                          /* nb_index */
+	#if PY_VERSION_HEX >= 0x02050000
+	(unaryfunc)0,               /* nb_index */
+	#endif
 };
 
 
 PyTypeObject Variable_Type = {
-	PyObject_HEAD_INIT( 0 )
-	0,                                      /* ob_size */
+	PyVarObject_HEAD_INIT( &PyType_Type, 0 )
 	"pykiwi.Variable",                      /* tp_name */
 	sizeof( Variable ),                     /* tp_basicsize */
 	0,                                      /* tp_itemsize */
@@ -256,7 +297,11 @@ PyTypeObject Variable_Type = {
 	(getattrofunc)0,                        /* tp_getattro */
 	(setattrofunc)0,                        /* tp_setattro */
 	(PyBufferProcs*)0,                      /* tp_as_buffer */
+	#if PY_MAJOR_VERSION >= 3
+	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC|Py_TPFLAGS_BASETYPE, /* tp_flags */
+	#else	
 	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES, /* tp_flags */
+	#endif
 	0,                                      /* Documentation string */
 	(traverseproc)Variable_traverse,        /* tp_traverse */
 	(inquiry)Variable_clear,                /* tp_clear */

--- a/tests/test_kiwi_solver_basic_sanity.py
+++ b/tests/test_kiwi_solver_basic_sanity.py
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2013, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-------------------------------------------------------------------------------
+
+from pykiwi import Solver, Variable, Constraint
+import unittest
+
+
+class KiwiSolverBasicSanityTests( unittest.TestCase ):
+	def test_adding_constraints_to_solver( self ):
+		s = Solver()
+		x0 = Variable( 'x0' )
+		x1 = Variable( 'x1' )
+		s.addConstraint( x0 >= 0 )
+		s.addConstraint( x1 >= 0 )
+		s.solve()
+
+		self.assertEqual( x0.value(), 0.0 )
+		self.assertEqual( x1.value(), 0.0 )
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
Hey Chris, 

Here's Python 3 support for Kiwi, tested on 2.7, 3.3.2 and 3.4a4 on OS X Mavericks and a gentoo build.

I realise the project is mostly WIP right now, but it'd be good to add py3 support :) 
i've left the base kiwi solver code alone and just changed the python wrapper to do the bytes/str conversions. this seemed more sane than attempting to change the kiwi solver to use unicode! 

also, have added a *very* basic unit test to create a solver and add constraints - this proved really useful when getting the build working for 2.x and 3.x, however i stopped short of putting in an entire test suite, as i assumed you're still playing with the solver code :)

am more than willing to put in numerical tests when you're happy with the solver.

cheers,
dave