### PR TITLE
Allow creation of Variable with no parameters

### DIFF
--- a/kiwi/variable.h
+++ b/kiwi/variable.h
@@ -25,9 +25,9 @@ public:
 		Context() {}
 		virtual ~Context() {}
     };
-    
-    Variable() :
-        m_data( new VariableData( "", 0 ) ) {}
+
+  Variable() :
+    m_data( new VariableData( "", 0 ) ) {}
 
 	Variable( const std::string& name, Context* context = 0 ) :
 		m_data( new VariableData( name, context ) ) {}

--- a/kiwi/variable.h
+++ b/kiwi/variable.h
@@ -24,7 +24,10 @@ public:
 	public:
 		Context() {}
 		virtual ~Context() {}
-	};
+    };
+    
+    Variable() :
+        m_data( new VariableData( "", 0 ) ) {}
 
 	Variable( const std::string& name, Context* context = 0 ) :
 		m_data( new VariableData( name, context ) ) {}


### PR DESCRIPTION
This is required when using Variable as a value in a AssocVector map. (I'm doing that outside of Kiwi)
