### PR TITLE
Don't require variable names

### DIFF
--- a/kiwi/variable.h
+++ b/kiwi/variable.h
@@ -26,6 +26,9 @@ public:
 		virtual ~Context() {}
 	};
 
+	Variable( Context* context = 0 ) :
+		m_data( new VariableData( "", context ) ) {}
+
 	Variable( const std::string& name, Context* context = 0 ) :
 		m_data( new VariableData( name, context ) ) {}
 


### PR DESCRIPTION
Adds a non-ambiguous constructor that simply initializes the variable name to an empty string.

Fixes #19. Closes #29. Not sure what that PR was attempting but that was definitely not the API change that should have happened in my opinion. Plus, this one has proper formatting.

Thanks for a great library, by the way :)