### PR TITLE
Fix to allow unicode py2.7

### DIFF
--- a/py/pythonhelpers.h
+++ b/py/pythonhelpers.h
@@ -11,14 +11,14 @@
 #include <string>
 
 #if PY_MAJOR_VERSION >= 3
-#define FROM_STRING PyUnicode_FromString
 #define INITERROR return NULL
 #define MOD_INIT_FUNC(name) PyMODINIT_FUNC PyInit_##name(void)
 #else
-#define FROM_STRING PyString_FromString
 #define INITERROR return
 #define MOD_INIT_FUNC(name) PyMODINIT_FUNC init##name(void)
 #endif
+
+#define FROM_STRING PyUnicode_FromString
 
 #ifndef Py_RETURN_NOTIMPLEMENTED
 #define Py_RETURN_NOTIMPLEMENTED \

--- a/py/pythonhelpers.h
+++ b/py/pythonhelpers.h
@@ -11,14 +11,14 @@
 #include <string>
 
 #if PY_MAJOR_VERSION >= 3
+#define FROM_STRING PyUnicode_FromString
 #define INITERROR return NULL
 #define MOD_INIT_FUNC(name) PyMODINIT_FUNC PyInit_##name(void)
 #else
+#define FROM_STRING PyString_FromString
 #define INITERROR return
 #define MOD_INIT_FUNC(name) PyMODINIT_FUNC init##name(void)
 #endif
-
-#define FROM_STRING PyUnicode_FromString
 
 #ifndef Py_RETURN_NOTIMPLEMENTED
 #define Py_RETURN_NOTIMPLEMENTED \

--- a/py/tests/test_constraint.py
+++ b/py/tests/test_constraint.py
@@ -6,8 +6,6 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-import sys
-import pytest
 from kiwisolver import Variable, Constraint, strength
 
 
@@ -29,10 +27,6 @@ def test_constraint_creation():
     for s in ('weak', 'medium', 'strong', 'required'):
         c = Constraint(v + 1, '>=', s)
         assert c.strength() == getattr(strength, s)
-
-    if sys.version_info < (3,):
-        with pytest.raises(UnicodeEncodeError):
-            c = Constraint(v + 1, '>=', u'γ')
 
 
 def test_constraint_or_operator():

--- a/py/tests/test_constraint.py
+++ b/py/tests/test_constraint.py
@@ -38,7 +38,7 @@ def test_constraint_or_operator():
     for s in (u'weak', 'medium', 'strong', u'required',
               strength.create(1, 1, 0)):
         c2 = c | s
-        if isinstance(s, str):
+        if isinstance(s, (type(''), type(u''))):
             assert c2.strength() == getattr(strength, s)
         else:
             assert c2.strength() == s

--- a/py/tests/test_constraint.py
+++ b/py/tests/test_constraint.py
@@ -31,7 +31,7 @@ def test_constraint_creation():
         assert c.strength() == getattr(strength, s)
 
     if sys.version_info < (3,):
-        with pytest.raises(UnicodeDecodeError):
+        with pytest.raises(UnicodeEncodeError):
             c = Constraint(v + 1, '>=', u'γ')
 
 

--- a/py/tests/test_constraint.py
+++ b/py/tests/test_constraint.py
@@ -35,7 +35,7 @@ def test_constraint_or_operator():
     v = Variable('foo')
     c = Constraint(v + 1, '==')
 
-    for s in ('weak', 'medium', 'strong', 'required',
+    for s in (u'weak', 'medium', 'strong', u'required',
               strength.create(1, 1, 0)):
         c2 = c | s
         if isinstance(s, str):

--- a/py/tests/test_constraint.py
+++ b/py/tests/test_constraint.py
@@ -40,7 +40,7 @@ def test_constraint_or_operator():
 
     """
     v = Variable('foo')
-    c = Constraint(v + 1, '==')
+    c = Constraint(v + 1, u'==')
 
     for s in (u'weak', 'medium', 'strong', u'required',
               strength.create(1, 1, 0)):

--- a/py/tests/test_constraint.py
+++ b/py/tests/test_constraint.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #------------------------------------------------------------------------------
 # Copyright (c) 2014-2017, Nucleic Development Team.
 #
@@ -5,6 +6,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+import sys
+import pytest
 from kiwisolver import Variable, Constraint, strength
 
 
@@ -26,6 +29,10 @@ def test_constraint_creation():
     for s in ('weak', 'medium', 'strong', 'required'):
         c = Constraint(v + 1, '>=', s)
         assert c.strength() == getattr(strength, s)
+
+    if sys.version_info < (3,):
+        with pytest.raises(UnicodeDecodeError):
+            c = Constraint(v + 1, '>=', u'γ')
 
 
 def test_constraint_or_operator():

--- a/py/tests/test_variable.py
+++ b/py/tests/test_variable.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #------------------------------------------------------------------------------
 # Copyright (c) 2014-2017, Nucleic Development Team.
 #
@@ -25,6 +26,9 @@ def test_variable_methods():
     if sys.version_info >= (3,):
         with pytest.raises(TypeError):
             v.setName(b'r')
+    if sys.version_info < (3,):
+        with pytest.raises(UnicodeDecodeError):
+            v.setName(u'γ')
 
     assert v.value() == 0.0
 

--- a/py/tests/test_variable.py
+++ b/py/tests/test_variable.py
@@ -97,7 +97,7 @@ def test_variable_rich_compare_operations():
 
     """
     v = Variable('foo')
-    v2 = Variable(u'bar')
+    v2 = Variable(u'γ')
 
     for op, symbol in ((operator.le, '<='), (operator.eq, '=='),
                        (operator.ge, '>=')):

--- a/py/tests/test_variable.py
+++ b/py/tests/test_variable.py
@@ -19,9 +19,9 @@ def test_variable_methods():
     """
     v = Variable()
     assert v.name() == ""
-    v.setName('bar')
-    assert v.name() == 'bar'
-    v.setName(u'foo')
+    v.setName(u'γ')
+    assert v.name() == 'γ'
+    v.setName('foo')
     assert v.name() == 'foo'
     if sys.version_info >= (3,):
         with pytest.raises(TypeError):

--- a/py/tests/test_variable.py
+++ b/py/tests/test_variable.py
@@ -32,7 +32,7 @@ def test_variable_methods():
     v.setContext(ctx)
     assert v.context() is ctx
 
-    assert str(v) == 'bar'
+    assert str(v) == 'foo'
 
 
 def test_variable_arith_operators():

--- a/py/tests/test_variable.py
+++ b/py/tests/test_variable.py
@@ -26,9 +26,6 @@ def test_variable_methods():
     if sys.version_info >= (3,):
         with pytest.raises(TypeError):
             v.setName(b'r')
-    if sys.version_info < (3,):
-        with pytest.raises(UnicodeEncodeError):
-            v.setName(u'γ')
 
     assert v.value() == 0.0
 

--- a/py/tests/test_variable.py
+++ b/py/tests/test_variable.py
@@ -20,11 +20,11 @@ def test_variable_methods():
     assert v.name() == ""
     v.setName('bar')
     assert v.name() == 'bar'
+    v.setName(u'foo')
+    assert v.name() == 'foo'
     with pytest.raises(TypeError):
         if sys.version_info >= (3,):
             v.setName(b'r')
-        else:
-            v.setName(u'r')
 
     assert v.value() == 0.0
 
@@ -96,7 +96,7 @@ def test_variable_rich_compare_operations():
 
     """
     v = Variable('foo')
-    v2 = Variable('bar')
+    v2 = Variable(u'bar')
 
     for op, symbol in ((operator.le, '<='), (operator.eq, '=='),
                        (operator.ge, '>=')):

--- a/py/tests/test_variable.py
+++ b/py/tests/test_variable.py
@@ -22,8 +22,8 @@ def test_variable_methods():
     assert v.name() == 'bar'
     v.setName(u'foo')
     assert v.name() == 'foo'
-    with pytest.raises(TypeError):
-        if sys.version_info >= (3,):
+    if sys.version_info >= (3,):
+        with pytest.raises(TypeError):
             v.setName(b'r')
 
     assert v.value() == 0.0

--- a/py/tests/test_variable.py
+++ b/py/tests/test_variable.py
@@ -27,7 +27,7 @@ def test_variable_methods():
         with pytest.raises(TypeError):
             v.setName(b'r')
     if sys.version_info < (3,):
-        with pytest.raises(UnicodeDecodeError):
+        with pytest.raises(UnicodeEncodeError):
             v.setName(u'γ')
 
     assert v.value() == 0.0

--- a/py/util.h
+++ b/py/util.h
@@ -51,10 +51,12 @@ convert_to_strength( PyObject* value, double& out )
     {
       str = PyUnicode_AsUTF8( value );
 #else
+    PyObject* ascii_str;
+
     if( PyString_Check( value ) | PyUnicode_Check( value ))
     {
       if( PyUnicode_Check( value ) )
-          PyObject* ascii_str = PyUnicode_AsASCIIString( value );
+          ascii_str = PyUnicode_AsASCIIString( value );
           str = PyString_AS_STRING( ascii_str );
           Py_DECREF( ascii_str );
       else

--- a/py/util.h
+++ b/py/util.h
@@ -44,7 +44,7 @@ convert_to_double( PyObject* obj, double& out )
 inline bool
 convert_to_strength( PyObject* value, double& out )
 {
-  std::string str;
+    std::string str;
 
 #if PY_MAJOR_VERSION >= 3
     if( PyUnicode_Check( value ) )
@@ -58,6 +58,8 @@ convert_to_strength( PyObject* value, double& out )
       if( PyUnicode_Check( value ) )
       {
           ascii_str = PyUnicode_AsASCIIString( value );
+          if( !ascii_str )
+              return 0;
           str = PyString_AS_STRING( ascii_str );
           Py_DECREF( ascii_str );
       }

--- a/py/util.h
+++ b/py/util.h
@@ -47,7 +47,7 @@ convert_pystr_to_str( PyObject* value, std::string& out )
 #if PY_MAJOR_VERSION >= 3
     out = PyUnicode_AsUTF8( value );
 #else
-    if( PyUnicode_Check( pystr ) )
+    if( PyUnicode_Check( value ) )
     {
         PythonHelpers::PyObjectPtr py_str( PyUnicode_AsUTF8String( value ) );
         if( !py_str )

--- a/py/util.h
+++ b/py/util.h
@@ -52,7 +52,7 @@ convert_pystr_to_str( PyObject* pystr, std::string& out )
         PythonHelpers::PyObjectPtr py_str( PyUnicode_AsUTF8String( value ) );
         if( !py_str )
              return false;
-        out = PyString_AS_STRING( py_str.get() ) );
+        out = PyString_AS_STRING( py_str.get() );
     }
     else
         out = PyString_AS_STRING( pystr ) );

--- a/py/util.h
+++ b/py/util.h
@@ -42,10 +42,10 @@ convert_to_double( PyObject* obj, double& out )
 
 
 inline bool
-convert_pystr_to_str( PyObject* pystr, std::string& out )
+convert_pystr_to_str( PyObject* value, std::string& out )
 {
 #if PY_MAJOR_VERSION >= 3
-    std::string str( PyUnicode_AsUTF8( pystr ) );
+    out = PyUnicode_AsUTF8( value );
 #else
     if( PyUnicode_Check( pystr ) )
     {
@@ -55,7 +55,7 @@ convert_pystr_to_str( PyObject* pystr, std::string& out )
         out = PyString_AS_STRING( py_str.get() );
     }
     else
-        out = PyString_AS_STRING( pystr );
+        out = PyString_AS_STRING( value );
 #endif
     return true;
 }

--- a/py/util.h
+++ b/py/util.h
@@ -54,7 +54,7 @@ convert_to_strength( PyObject* value, double& out )
     if( PyString_Check( value ) | PyUnicode_Check( value ))
     {
       if( PyUnicode_Check( value ) )
-          ascii_str = PyUnicode_AsASCIIString( value );
+          PyObject* ascii_str = PyUnicode_AsASCIIString( value );
           str = PyString_AS_STRING( ascii_str );
           Py_DECREF( ascii_str );
       else

--- a/py/util.h
+++ b/py/util.h
@@ -54,7 +54,7 @@ convert_to_strength( PyObject* value, double& out )
     if( PyString_Check( value ) | PyUnicode_Check( value ))
     {
       if( PyUnicode_Check( value ) )
-          str = PyUnicode_AsUTF8( value ) );
+          str = PyString_AS_STRING(PyUnicode_AsASCIIString( value );
       else
           str = PyString_AS_STRING( value ) ;
 #endif

--- a/py/util.h
+++ b/py/util.h
@@ -44,14 +44,19 @@ convert_to_double( PyObject* obj, double& out )
 inline bool
 convert_to_strength( PyObject* value, double& out )
 {
+  std::string str;
+
 #if PY_MAJOR_VERSION >= 3
     if( PyUnicode_Check( value ) )
     {
-        std::string str( PyUnicode_AsUTF8( value ) );
+      str = PyUnicode_AsUTF8( value );
 #else
-    if( PyString_Check( value ) )
+    if( PyString_Check( value ) | PyUnicode_Check( value ))
     {
-        std::string str( PyString_AS_STRING( value ) );
+      if( PyUnicode_Check( value ) )
+          str = PyString_AS_STRING(PyUnicode_AsASCIIString( value ) );
+      else
+          str = PyString_AS_STRING( value ) ;
 #endif
         if( str == "required" )
             out = kiwi::strength::required;

--- a/py/util.h
+++ b/py/util.h
@@ -54,7 +54,7 @@ convert_to_strength( PyObject* value, double& out )
     if( PyString_Check( value ) | PyUnicode_Check( value ))
     {
       if( PyUnicode_Check( value ) )
-          str = PyString_AS_STRING(PyUnicode_AsASCIIString( value ) );
+          str = PyUnicode_AsUTF8( value ) );
       else
           str = PyString_AS_STRING( value ) ;
 #endif

--- a/py/util.h
+++ b/py/util.h
@@ -56,9 +56,11 @@ convert_to_strength( PyObject* value, double& out )
     if( PyString_Check( value ) | PyUnicode_Check( value ))
     {
       if( PyUnicode_Check( value ) )
+      {
           ascii_str = PyUnicode_AsASCIIString( value );
           str = PyString_AS_STRING( ascii_str );
           Py_DECREF( ascii_str );
+      }
       else
           str = PyString_AS_STRING( value ) ;
 #endif

--- a/py/util.h
+++ b/py/util.h
@@ -54,7 +54,9 @@ convert_to_strength( PyObject* value, double& out )
     if( PyString_Check( value ) | PyUnicode_Check( value ))
     {
       if( PyUnicode_Check( value ) )
-          str = PyUnicode_AsUTF8( value );
+          ascii_str = PyUnicode_AsASCIIString( value );
+          str = PyString_AS_STRING( ascii_str );
+          Py_DECREF( ascii_str );
       else
           str = PyString_AS_STRING( value ) ;
 #endif

--- a/py/util.h
+++ b/py/util.h
@@ -55,7 +55,7 @@ convert_pystr_to_str( PyObject* pystr, std::string& out )
         out = PyString_AS_STRING( py_str.get() );
     }
     else
-        out = PyString_AS_STRING( pystr ) );
+        out = PyString_AS_STRING( pystr );
 #endif
     return true;
 }

--- a/py/util.h
+++ b/py/util.h
@@ -54,7 +54,7 @@ convert_to_strength( PyObject* value, double& out )
     if( PyString_Check( value ) | PyUnicode_Check( value ))
     {
       if( PyUnicode_Check( value ) )
-          str = PyString_AS_STRING(PyUnicode_AsASCIIString( value );
+          str = PyUnicode_AsUTF8( value );
       else
           str = PyString_AS_STRING( value ) ;
 #endif

--- a/py/variable.cpp
+++ b/py/variable.cpp
@@ -92,28 +92,17 @@ Variable_setName( Variable* self, PyObject* pystr )
 #if PY_MAJOR_VERSION >= 3
 	if( !PyUnicode_Check( pystr ) )
 		return py_expected_type_fail( pystr, "unicode" );
-	self->variable.setName( PyUnicode_AsUTF8( pystr ) );
 #else
-   std::string str;
-   PyObject* ascii_str;
-
-   if( PyString_Check( pystr ) | PyUnicode_Check( pystr ))
-   {
-     if( PyUnicode_Check( pystr ) )
-     {
-         ascii_str = PyUnicode_AsASCIIString( pystr );
-         if( !ascii_str )
-             return 0;
-         str = PyString_AS_STRING( ascii_str );
-         Py_DECREF( ascii_str );
-     }
-     else
-         str = PyString_AS_STRING( pystr ) ;
-   }
-	else
-		return py_expected_type_fail( pystr, "str or unicode" );
-	self->variable.setName( str );
+   if( !(PyString_Check( value ) | PyUnicode_Check( value ) ) )
+    {
+        PythonHelpers::py_expected_type_fail( value, "str or unicode" );
+        return false;
+    }
 #endif
+   std::string str;
+   if( !convert_pystr_to_str( pystr, str ) )
+       return false;
+   self->variable.setName( str );
 	Py_RETURN_NONE;
 }
 

--- a/py/variable.cpp
+++ b/py/variable.cpp
@@ -22,9 +22,9 @@ Variable_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
 	static const char *kwlist[] = { "name", "context", 0 };
 	PyObject* context = 0;
 
-	const char* name = 0;
+	PyObject* name;
 	if( !PyArg_ParseTupleAndKeywords(
-		args, kwargs, "|sO:__new__", const_cast<char**>( kwlist ),
+		args, kwargs, "|OO:__new__", const_cast<char**>( kwlist ),
 		&name, &context ) )
 		return 0;
 
@@ -36,7 +36,19 @@ Variable_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
 
    if( name != 0 )
    {
-    	new( &self->variable ) kiwi::Variable( name );
+#if PY_MAJOR_VERSION >= 3
+      if( !PyUnicode_Check( name ) )
+    	   return py_expected_type_fail( name, "unicode" );
+#else
+      if( !(PyString_Check( name ) | PyUnicode_Check( name ) ) )
+      {
+         return py_expected_type_fail( name, "str or unicode" );
+      }
+#endif
+      std::string c_name;
+      if( !convert_pystr_to_str(name, c_name) )
+          return 0;
+    	new( &self->variable ) kiwi::Variable( c_name );
    }
    else
    {

--- a/py/variable.cpp
+++ b/py/variable.cpp
@@ -22,19 +22,12 @@ Variable_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
 	static const char *kwlist[] = { "name", "context", 0 };
 	PyObject* context = 0;
 
-#if PY_MAJOR_VERSION >= 3
 	const char* name = 0;
 	if( !PyArg_ParseTupleAndKeywords(
 		args, kwargs, "|sO:__new__", const_cast<char**>( kwlist ),
 		&name, &context ) )
 		return 0;
-#else
-	PyObject* name = 0;
-	if( !PyArg_ParseTupleAndKeywords(
-		args, kwargs, "|SO:__new__", const_cast<char**>( kwlist ),
-		&name, &context ) )
-		return 0;
-#endif
+
 	PyObject* pyvar = PyType_GenericNew( type, args, kwargs );
 	if( !pyvar )
 		return 0;
@@ -43,11 +36,7 @@ Variable_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
 
    if( name != 0 )
    {
-#if PY_MAJOR_VERSION >= 3
     	new( &self->variable ) kiwi::Variable( name );
-#else
-    	new( &self->variable ) kiwi::Variable( PyString_AS_STRING( name ) );
-#endif
    }
    else
    {

--- a/py/variable.cpp
+++ b/py/variable.cpp
@@ -21,8 +21,8 @@ Variable_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
 {
 	static const char *kwlist[] = { "name", "context", 0 };
 	PyObject* context = 0;
+	PyObject* name = 0;
 
-	PyObject* name;
 	if( !PyArg_ParseTupleAndKeywords(
 		args, kwargs, "|OO:__new__", const_cast<char**>( kwlist ),
 		&name, &context ) )

--- a/py/variable.cpp
+++ b/py/variable.cpp
@@ -94,9 +94,22 @@ Variable_setName( Variable* self, PyObject* pystr )
 		return py_expected_type_fail( pystr, "unicode" );
 	self->variable.setName( PyUnicode_AsUTF8( pystr ) );
 #else
-	if( !PyString_Check( pystr ) )
+   std::string str;
+   PyObject* ascii_str;
+
+   if( PyString_Check( value ) | PyUnicode_Check( value ))
+   {
+     if( PyUnicode_Check( value ) )
+     {
+         ascii_str = PyUnicode_AsASCIIString( value );
+         str = PyString_AS_STRING( ascii_str );
+         Py_DECREF( ascii_str );
+     }
+     else
+         str = PyString_AS_STRING( value ) ;
+	else
 		return py_expected_type_fail( pystr, "str" );
-	self->variable.setName( PyString_AS_STRING( pystr ) );
+	self->variable.setName( str );
 #endif
 	Py_RETURN_NONE;
 }

--- a/py/variable.cpp
+++ b/py/variable.cpp
@@ -97,18 +97,18 @@ Variable_setName( Variable* self, PyObject* pystr )
    std::string str;
    PyObject* ascii_str;
 
-   if( PyString_Check( value ) | PyUnicode_Check( value ))
+   if( PyString_Check( pystr ) | PyUnicode_Check( pystr ))
    {
-     if( PyUnicode_Check( value ) )
+     if( PyUnicode_Check( pystr ) )
      {
-         ascii_str = PyUnicode_AsASCIIString( value );
+         ascii_str = PyUnicode_AsASCIIString( pystr );
          str = PyString_AS_STRING( ascii_str );
          Py_DECREF( ascii_str );
      }
      else
-         str = PyString_AS_STRING( value ) ;
+         str = PyString_AS_STRING( pystr ) ;
 	else
-		return py_expected_type_fail( pystr, "str" );
+		return py_expected_type_fail( pystr, "str or unicode" );
 	self->variable.setName( str );
 #endif
 	Py_RETURN_NONE;

--- a/py/variable.cpp
+++ b/py/variable.cpp
@@ -93,15 +93,14 @@ Variable_setName( Variable* self, PyObject* pystr )
 	if( !PyUnicode_Check( pystr ) )
 		return py_expected_type_fail( pystr, "unicode" );
 #else
-   if( !(PyString_Check( py_str ) | PyUnicode_Check( py_str ) ) )
+   if( !(PyString_Check( pystr ) | PyUnicode_Check( pystr ) ) )
     {
-        PythonHelpers::py_expected_type_fail( value, "str or unicode" );
-        return false;
+        return py_expected_type_fail( pystr, "str or unicode" );
     }
 #endif
    std::string str;
    if( !convert_pystr_to_str( pystr, str ) )
-       return false;
+       return 0;
    self->variable.setName( str );
 	Py_RETURN_NONE;
 }

--- a/py/variable.cpp
+++ b/py/variable.cpp
@@ -93,7 +93,7 @@ Variable_setName( Variable* self, PyObject* pystr )
 	if( !PyUnicode_Check( pystr ) )
 		return py_expected_type_fail( pystr, "unicode" );
 #else
-   if( !(PyString_Check( value ) | PyUnicode_Check( value ) ) )
+   if( !(PyString_Check( py_str ) | PyUnicode_Check( py_str ) ) )
     {
         PythonHelpers::py_expected_type_fail( value, "str or unicode" );
         return false;

--- a/py/variable.cpp
+++ b/py/variable.cpp
@@ -107,6 +107,7 @@ Variable_setName( Variable* self, PyObject* pystr )
      }
      else
          str = PyString_AS_STRING( pystr ) ;
+   }
 	else
 		return py_expected_type_fail( pystr, "str or unicode" );
 	self->variable.setName( str );

--- a/py/variable.cpp
+++ b/py/variable.cpp
@@ -28,34 +28,35 @@ Variable_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
 		&name, &context ) )
 		return 0;
 
-	PyObject* pyvar = PyType_GenericNew( type, args, kwargs );
+	PyObjectPtr pyvar( PyType_GenericNew( type, args, kwargs ) );
 	if( !pyvar )
 		return 0;
-	Variable* self = reinterpret_cast<Variable*>( pyvar );
+
+	Variable* self = reinterpret_cast<Variable*>( pyvar.get() );
 	self->context = xnewref( context );
 
-   if( name != 0 )
-   {
+	if( name != 0 )
+	{
 #if PY_MAJOR_VERSION >= 3
-      if( !PyUnicode_Check( name ) )
-    	   return py_expected_type_fail( name, "unicode" );
+		if( !PyUnicode_Check( name ) )
+			return py_expected_type_fail( name, "unicode" );
 #else
-      if( !(PyString_Check( name ) | PyUnicode_Check( name ) ) )
-      {
-         return py_expected_type_fail( name, "str or unicode" );
-      }
+		if( !( PyString_Check( name ) | PyUnicode_Check( name ) ) )
+		{
+			return py_expected_type_fail( name, "str or unicode" );
+		}
 #endif
-      std::string c_name;
-      if( !convert_pystr_to_str(name, c_name) )
-          return 0;
-    	new( &self->variable ) kiwi::Variable( c_name );
-   }
-   else
-   {
-      new( &self->variable ) kiwi::Variable();
-   }
+		std::string c_name;
+		if( !convert_pystr_to_str(name, c_name) )
+			return 0;
+		new( &self->variable ) kiwi::Variable( c_name );
+	}
+	else
+	{
+		new( &self->variable ) kiwi::Variable();
+	}
 
-	return pyvar;
+	return pyvar.release();
 }
 
 

--- a/py/variable.cpp
+++ b/py/variable.cpp
@@ -102,6 +102,8 @@ Variable_setName( Variable* self, PyObject* pystr )
      if( PyUnicode_Check( pystr ) )
      {
          ascii_str = PyUnicode_AsASCIIString( pystr );
+         if( !ascii_str )
+             return 0;
          str = PyString_AS_STRING( ascii_str );
          Py_DECREF( ascii_str );
      }

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -1,6 +1,11 @@
 Kiwi Release Notes
 ==================
 
+Wrappers x.x.x | Solver x.x.x | unreleased
+------------------------------------------
+- allow unicode strings for variable name in Python 2
+- allow unicode strings as strength specifiers in Python 2
+
 Wrappers 1.0.0 | Solver 1.0.0 | 09/06/2017
 ------------------------------------------
 - Allow anonymous variables (solver PR #32, wrappers PR #22)


### PR DESCRIPTION
This is to fix https://github.com/nucleic/kiwi/issues/39.  It works on the test I have.  I admit I didn't run the other tests.  

It basically allows `from __future__ import unicode_literals` to be used in python 2.7.  I tested in Python 2.7 with and with out that line at the top for the test, and in python 3 w/ that line.  

```python
from __future__ import unicode_literals

import kiwisolver as kiwi

Variable = kiwi.Variable
solver = kiwi.Solver()
top = Variable('boo')
c = (top == 1.0)
solver.addConstraint(c | 'strong')
solver.dump()
```

@sccolbert @MatthieuDartiailh 

Thanks!