### PR TITLE
ARM64: Add ARM64 jobs in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,15 @@ jobs:
     python: 3.7
   - name: "run test suite with python 3.8"
     python: 3.8
+  - name: "run test suite with python 3.6 on ARM64"
+    arch: arm64
+    python: 3.6
+  - name: "run test suite with python 3.7 on ARM64"
+    arch: arm64
+    python: 3.7
+  - name: "run test suite with python 3.8 on ARM64"
+    arch: arm64
+    python: 3.8
 
 env:
   - CPPFLAGS=--coverage
@@ -38,4 +47,3 @@ after_success:
   - lcov --list coverage.info
   # Uploading to CodeCov but excluding gcov reports
   - bash <(curl -s https://codecov.io/bash) -f "!*.gcov" -X gcov || echo "Codecov did not collect coverage reports"
-


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 jobs in Travis-CI.