### PR TITLE
Improve performance by making use of C++11 movement.

### DIFF
--- a/kiwi/constraint.h
+++ b/kiwi/constraint.h
@@ -36,6 +36,8 @@ public:
 
     Constraint(const Constraint &other, double strength) : m_data(new ConstraintData(other, strength)) {}
 
+    Constraint(const Constraint &) = default;
+
     Constraint(Constraint &&) = default;
 
     ~Constraint() {}

--- a/kiwi/constraint.h
+++ b/kiwi/constraint.h
@@ -67,7 +67,7 @@ private:
         for (iter_t it = expr.terms().begin(); it != end; ++it)
             vars[it->variable()] += it->coefficient();
         std::vector<Term> terms(vars.begin(), vars.end());
-        return Expression(terms, expr.constant());
+        return Expression(std::move(terms), expr.constant());
     }
 
     class ConstraintData : public SharedData

--- a/kiwi/constraint.h
+++ b/kiwi/constraint.h
@@ -36,6 +36,8 @@ public:
 
     Constraint(const Constraint &other, double strength) : m_data(new ConstraintData(other, strength)) {}
 
+    Constraint(Constraint &&) = default;
+
     ~Constraint() {}
 
     const Expression &expression() const

--- a/kiwi/constraint.h
+++ b/kiwi/constraint.h
@@ -62,6 +62,10 @@ public:
         return !m_data;
     }
 
+    Constraint& operator=(const Constraint &) = default;
+
+    Constraint& operator=(Constraint &&) = default;
+
 private:
     static Expression reduce(const Expression &expr)
     {

--- a/kiwi/constraint.h
+++ b/kiwi/constraint.h
@@ -38,7 +38,7 @@ public:
 
     Constraint(const Constraint &) = default;
 
-    Constraint(Constraint &&) = default;
+    Constraint(Constraint &&) noexcept = default;
 
     ~Constraint() = default;
 
@@ -64,7 +64,7 @@ public:
 
     Constraint& operator=(const Constraint &) = default;
 
-    Constraint& operator=(Constraint &&) = default;
+    Constraint& operator=(Constraint &&) noexcept = default;
 
 private:
     static Expression reduce(const Expression &expr)

--- a/kiwi/errors.h
+++ b/kiwi/errors.h
@@ -18,7 +18,7 @@ class UnsatisfiableConstraint : public std::exception
 {
 
 public:
-    UnsatisfiableConstraint(const Constraint &constraint) : m_constraint(constraint) {}
+    UnsatisfiableConstraint(Constraint constraint) : m_constraint(std::move(constraint)) {}
 
     ~UnsatisfiableConstraint() throw() {}
 
@@ -40,7 +40,7 @@ class UnknownConstraint : public std::exception
 {
 
 public:
-    UnknownConstraint(const Constraint &constraint) : m_constraint(constraint) {}
+    UnknownConstraint(Constraint constraint) : m_constraint(std::move(constraint)) {}
 
     ~UnknownConstraint() throw() {}
 
@@ -62,7 +62,7 @@ class DuplicateConstraint : public std::exception
 {
 
 public:
-    DuplicateConstraint(const Constraint &constraint) : m_constraint(constraint) {}
+    DuplicateConstraint(Constraint constraint) : m_constraint(std::move(constraint)) {}
 
     ~DuplicateConstraint() throw() {}
 
@@ -84,7 +84,7 @@ class UnknownEditVariable : public std::exception
 {
 
 public:
-    UnknownEditVariable(const Variable &variable) : m_variable(variable) {}
+    UnknownEditVariable(Variable variable) : m_variable(std::move(variable)) {}
 
     ~UnknownEditVariable() throw() {}
 
@@ -106,7 +106,7 @@ class DuplicateEditVariable : public std::exception
 {
 
 public:
-    DuplicateEditVariable(const Variable &variable) : m_variable(variable) {}
+    DuplicateEditVariable(Variable variable) : m_variable(std::move(variable)) {}
 
     ~DuplicateEditVariable() throw() {}
 
@@ -146,7 +146,7 @@ public:
 
     InternalSolverError(const char *msg) : m_msg(msg) {}
 
-    InternalSolverError(const std::string &msg) : m_msg(msg) {}
+    InternalSolverError(std::string msg) : m_msg(std::move(msg)) {}
 
     ~InternalSolverError() throw() {}
 

--- a/kiwi/expression.h
+++ b/kiwi/expression.h
@@ -20,9 +20,13 @@ public:
 
     Expression(const Term &term, double constant = 0.0) : m_terms(1, term), m_constant(constant) {}
 
-    Expression(const std::vector<Term> &terms, double constant = 0.0) : m_terms(terms), m_constant(constant) {}
+    Expression(std::vector<Term> terms, double constant = 0.0) : m_terms(std::move(terms)), m_constant(constant) {}
 
-    ~Expression() {}
+    Expression(const Expression&) = default;
+
+    Expression(Expression&&) = default;
+
+    ~Expression() = default;
 
     const std::vector<Term> &terms() const
     {
@@ -43,6 +47,10 @@ public:
             result += it->value();
         return result;
     }
+
+    Expression& operator=(const Expression&) = default;
+
+    Expression& operator=(Expression&&) = default;
 
 private:
     std::vector<Term> m_terms;

--- a/kiwi/expression.h
+++ b/kiwi/expression.h
@@ -24,7 +24,7 @@ public:
 
     Expression(const Expression&) = default;
 
-    Expression(Expression&&) = default;
+    Expression(Expression&&) noexcept = default;
 
     ~Expression() = default;
 
@@ -50,7 +50,7 @@ public:
 
     Expression& operator=(const Expression&) = default;
 
-    Expression& operator=(Expression&&) = default;
+    Expression& operator=(Expression&&) noexcept = default;
 
 private:
     std::vector<Term> m_terms;

--- a/kiwi/shareddata.h
+++ b/kiwi/shareddata.h
@@ -111,7 +111,7 @@ public:
         incref(m_data);
     }
 
-    SharedDataPtr(SharedDataPtr&& other) : m_data(other.m_data)
+    SharedDataPtr(SharedDataPtr&& other) noexcept : m_data(other.m_data)
     {
         other.m_data = nullptr;
     }
@@ -128,7 +128,7 @@ public:
         return *this;
     }
 
-    SharedDataPtr<T>& operator=(SharedDataPtr<T>&& other)
+    SharedDataPtr<T>& operator=(SharedDataPtr<T>&& other) noexcept
     {
         if (m_data != other.m_data)
         {

--- a/kiwi/shareddata.h
+++ b/kiwi/shareddata.h
@@ -108,6 +108,11 @@ public:
         incref(m_data);
     }
 
+    SharedDataPtr(SharedDataPtr&& other) : m_data(other.m_data)
+    {
+        other.m_data = nullptr;
+    }
+
     SharedDataPtr<T> &operator=(const SharedDataPtr<T> &other)
     {
         if (m_data != other.m_data)
@@ -116,6 +121,18 @@ public:
             m_data = other.m_data;
             incref(m_data);
             decref(temp);
+        }
+        return *this;
+    }
+
+    SharedDataPtr<T>& operator=(SharedDataPtr<T>&& other)
+    {
+        if (m_data != other.m_data)
+        {
+            decref(m_data);
+
+            m_data = other.m_data;
+            other.m_data = nullptr;
         }
         return *this;
     }

--- a/kiwi/symbolics.h
+++ b/kiwi/symbolics.h
@@ -74,7 +74,7 @@ Expression operator*( const Expression& expression, double coefficient )
 	iter_t end = expression.terms().end();
 	for( iter_t it = begin; it != end; ++it )
 		terms.push_back( ( *it ) * coefficient );
-	return Expression( terms, expression.constant() * coefficient );
+	return Expression( std::move(terms), expression.constant() * coefficient );
 }
 
 
@@ -124,7 +124,7 @@ Expression operator+( const Expression& first, const Expression& second )
 	terms.reserve( first.terms().size() + second.terms().size() );
 	terms.insert( terms.begin(), first.terms().begin(), first.terms().end() );
 	terms.insert( terms.end(), second.terms().begin(), second.terms().end() );
-	return Expression( terms, first.constant() + second.constant() );
+	return Expression( std::move(terms), first.constant() + second.constant() );
 }
 
 
@@ -135,7 +135,7 @@ Expression operator+( const Expression& first, const Term& second )
 	terms.reserve( first.terms().size() + 1 );
 	terms.insert( terms.begin(), first.terms().begin(), first.terms().end() );
 	terms.push_back( second );
-	return Expression( terms, first.constant() );
+	return Expression( std::move(terms), first.constant() );
 }
 
 

--- a/kiwi/term.h
+++ b/kiwi/term.h
@@ -27,7 +27,7 @@ public:
 
 	Term(const Term&) = default;
 
-	Term(Term&&) = default;
+	Term(Term&&) noexcept = default;
 
 	~Term() = default;
 
@@ -48,7 +48,7 @@ public:
 
 	Term& operator=(const Term&) = default;
 
-	Term& operator=(Term&&) = default;
+	Term& operator=(Term&&) noexcept = default;
 
 private:
 

--- a/kiwi/term.h
+++ b/kiwi/term.h
@@ -18,14 +18,18 @@ class Term
 
 public:
 
-	Term( const Variable& variable, double coefficient = 1.0 ) :
-		m_variable( variable ), m_coefficient( coefficient ) {}
+	Term( Variable variable, double coefficient = 1.0 ) :
+		m_variable( std::move(variable) ), m_coefficient( coefficient ) {}
 
 	// to facilitate efficient map -> vector copies
 	Term( const std::pair<const Variable, double>& pair ) :
 		m_variable( pair.first ), m_coefficient( pair.second ) {}
 
-	~Term() {}
+	Term(const Term&) = default;
+
+	Term(Term&&) = default;
+
+	~Term() = default;
 
 	const Variable& variable() const
 	{
@@ -41,6 +45,10 @@ public:
 	{
 		return m_coefficient * m_variable.value();
 	}
+
+	Term& operator=(const Term&) = default;
+
+	Term& operator=(Term&&) = default;
 
 private:
 

--- a/kiwi/variable.h
+++ b/kiwi/variable.h
@@ -30,7 +30,11 @@ public:
 
     Variable(const char *name, Context *context = 0) : m_data(new VariableData(name, context)) {}
 
-    ~Variable() {}
+    Variable(const Variable&) = default;
+
+    Variable(Variable&&) = default;
+
+    ~Variable() = default;
 
     const std::string &name() const
     {
@@ -73,6 +77,10 @@ public:
         return m_data == other.m_data;
     }
 
+    Variable& operator=(const Variable&) = default;
+
+    Variable& operator=(Variable&&) = default;
+
 private:
     class VariableData : public SharedData
     {
@@ -88,7 +96,7 @@ private:
                                                            m_context(context),
                                                            m_value(0.0) {}
 
-        ~VariableData() {}
+        ~VariableData() = default;
 
         std::string m_name;
         std::unique_ptr<Context> m_context;

--- a/kiwi/variable.h
+++ b/kiwi/variable.h
@@ -26,7 +26,7 @@ public:
 
     Variable(Context *context = 0) : m_data(new VariableData("", context)) {}
 
-    Variable(const std::string &name, Context *context = 0) : m_data(new VariableData(name, context)) {}
+    Variable(std::string name, Context *context = 0) : m_data(new VariableData(std::move(name), context)) {}
 
     Variable(const char *name, Context *context = 0) : m_data(new VariableData(name, context)) {}
 
@@ -86,8 +86,8 @@ private:
     {
 
     public:
-        VariableData(const std::string &name, Context *context) : SharedData(),
-                                                                  m_name(name),
+        VariableData(std::string name, Context *context) : SharedData(),
+                                                                  m_name(std::move(name)),
                                                                   m_context(context),
                                                                   m_value(0.0) {}
 

--- a/kiwi/variable.h
+++ b/kiwi/variable.h
@@ -32,7 +32,7 @@ public:
 
     Variable(const Variable&) = default;
 
-    Variable(Variable&&) = default;
+    Variable(Variable&&) noexcept = default;
 
     ~Variable() = default;
 
@@ -79,7 +79,7 @@ public:
 
     Variable& operator=(const Variable&) = default;
 
-    Variable& operator=(Variable&&) = default;
+    Variable& operator=(Variable&&) noexcept = default;
 
 private:
     class VariableData : public SharedData


### PR DESCRIPTION
Hi!

**Edit:** after using google/benchmark on a dedicated Linux server, it seems this PR doesn't do anything relative to `suggestValue` usage and the values below are just some noise.
**However** this PR does help a bit with solver building performance (which is not part of the python benchmark) and it still relevant, see #91.

C++11 introduced movement semantic, which can be used to prevent copying and reallocating vectors and just pass them instead, this does help with performance a bit.

I have consistent benchmark time, with
```
kiwi.suggestValue: Mean +- std dev: 8.83 us +- 0.10 us
kiwi.suggestValue: Mean +- std dev: 8.88 us +- 0.10 us
kiwi.suggestValue: Mean +- std dev: 8.92 us +- 0.12 us
```

before this change and

```
kiwi.suggestValue: Mean +- std dev: 8.52 us +- 0.08 us
kiwi.suggestValue: Mean +- std dev: 8.60 us +- 0.15 us
kiwi.suggestValue: Mean +- std dev: 8.58 us +- 0.14 us
```

after.

It's not much but I think it's worth it :)