### PR TITLE
Make C++11 code more idiomatic

### DIFF
--- a/kiwi/constraint.h
+++ b/kiwi/constraint.h
@@ -62,7 +62,7 @@ private:
     static Expression reduce(const Expression &expr)
     {
         std::map<Variable, double> vars;
-        for (const auto& term : expr.terms())
+        for (const auto & term : expr.terms())
             vars[term.variable()] += term.coefficient();
 
         std::vector<Term> terms(vars.begin(), vars.end());

--- a/kiwi/constraint.h
+++ b/kiwi/constraint.h
@@ -28,7 +28,7 @@ class Constraint
 {
 
 public:
-    Constraint() : m_data(0) {}
+    Constraint() = default;
 
     Constraint(const Expression &expr,
                RelationalOperator op,
@@ -36,7 +36,7 @@ public:
 
     Constraint(const Constraint &other, double strength) : m_data(new ConstraintData(other, strength)) {}
 
-    ~Constraint() {}
+    ~Constraint() = default;
 
     const Expression &expression() const
     {
@@ -62,10 +62,9 @@ private:
     static Expression reduce(const Expression &expr)
     {
         std::map<Variable, double> vars;
-        typedef std::vector<Term>::const_iterator iter_t;
-        iter_t end = expr.terms().end();
-        for (iter_t it = expr.terms().begin(); it != end; ++it)
-            vars[it->variable()] += it->coefficient();
+        for (const auto& term : expr.terms())
+            vars[term.variable()] += term.coefficient();
+
         std::vector<Term> terms(vars.begin(), vars.end());
         return Expression(terms, expr.constant());
     }
@@ -86,7 +85,7 @@ private:
                                                                    m_strength(strength::clip(strength)),
                                                                    m_op(other.op()) {}
 
-        ~ConstraintData() {}
+        ~ConstraintData() = default;
 
         Expression m_expression;
         double m_strength;

--- a/kiwi/debug.h
+++ b/kiwi/debug.h
@@ -54,64 +54,51 @@ public:
 
     static void dump(const SolverImpl::RowMap &rows, std::ostream &out)
     {
-        typedef SolverImpl::RowMap::const_iterator iter_t;
-        iter_t end = rows.end();
-        for (iter_t it = rows.begin(); it != end; ++it)
+        for (const auto& rowPair : rows)
         {
-            dump(it->first, out);
+            dump(rowPair.first, out);
             out << " | ";
-            dump(*it->second, out);
+            dump(*rowPair.second, out);
         }
     }
 
     static void dump(const std::vector<Symbol> &symbols, std::ostream &out)
     {
-        typedef std::vector<Symbol>::const_iterator iter_t;
-        iter_t end = symbols.end();
-        for (iter_t it = symbols.begin(); it != end; ++it)
+        for (const auto& symbol : symbols)
         {
-            dump(*it, out);
+            dump(symbol, out);
             out << std::endl;
         }
     }
 
     static void dump(const SolverImpl::VarMap &vars, std::ostream &out)
     {
-        typedef SolverImpl::VarMap::const_iterator iter_t;
-        iter_t end = vars.end();
-        for (iter_t it = vars.begin(); it != end; ++it)
+        for (const auto& varPair : vars)
         {
-            out << it->first.name() << " = ";
-            dump(it->second, out);
+            out << varPair.first.name() << " = ";
+            dump(varPair.second, out);
             out << std::endl;
         }
     }
 
     static void dump(const SolverImpl::CnMap &cns, std::ostream &out)
     {
-        typedef SolverImpl::CnMap::const_iterator iter_t;
-        iter_t end = cns.end();
-        for (iter_t it = cns.begin(); it != end; ++it)
-            dump(it->first, out);
+        for (const auto& cnPair : cns)
+            dump(cnPair.first, out);
     }
 
     static void dump(const SolverImpl::EditMap &edits, std::ostream &out)
     {
-        typedef SolverImpl::EditMap::const_iterator iter_t;
-        iter_t end = edits.end();
-        for (iter_t it = edits.begin(); it != end; ++it)
-            out << it->first.name() << std::endl;
+        for (const auto& editPair : edits)
+            out << editPair.first.name() << std::endl;
     }
 
     static void dump(const Row &row, std::ostream &out)
     {
-        typedef Row::CellMap::const_iterator iter_t;
-        out << row.constant();
-        iter_t end = row.cells().end();
-        for (iter_t it = row.cells().begin(); it != end; ++it)
+        for (const auto& rowPair : row.cells())
         {
-            out << " + " << it->second << " * ";
-            dump(it->first, out);
+            out << " + " << rowPair.second << " * ";
+            dump(rowPair.first, out);
         }
         out << std::endl;
     }
@@ -143,13 +130,10 @@ public:
 
     static void dump(const Constraint &cn, std::ostream &out)
     {
-        typedef std::vector<Term>::const_iterator iter_t;
-        iter_t begin = cn.expression().terms().begin();
-        iter_t end = cn.expression().terms().end();
-        for (iter_t it = begin; it != end; ++it)
+        for (const auto& term : cn.expression().terms())
         {
-            out << it->coefficient() << " * ";
-            out << it->variable().name() << " + ";
+            out << term.coefficient() << " * ";
+            out << term.variable().name() << " + ";
         }
         out << cn.expression().constant();
         switch (cn.op())

--- a/kiwi/debug.h
+++ b/kiwi/debug.h
@@ -54,7 +54,7 @@ public:
 
     static void dump(const SolverImpl::RowMap &rows, std::ostream &out)
     {
-        for (const auto& rowPair : rows)
+        for (const auto & rowPair : rows)
         {
             dump(rowPair.first, out);
             out << " | ";
@@ -64,7 +64,7 @@ public:
 
     static void dump(const std::vector<Symbol> &symbols, std::ostream &out)
     {
-        for (const auto& symbol : symbols)
+        for (const auto & symbol : symbols)
         {
             dump(symbol, out);
             out << std::endl;
@@ -73,7 +73,7 @@ public:
 
     static void dump(const SolverImpl::VarMap &vars, std::ostream &out)
     {
-        for (const auto& varPair : vars)
+        for (const auto & varPair : vars)
         {
             out << varPair.first.name() << " = ";
             dump(varPair.second, out);
@@ -83,19 +83,19 @@ public:
 
     static void dump(const SolverImpl::CnMap &cns, std::ostream &out)
     {
-        for (const auto& cnPair : cns)
+        for (const auto & cnPair : cns)
             dump(cnPair.first, out);
     }
 
     static void dump(const SolverImpl::EditMap &edits, std::ostream &out)
     {
-        for (const auto& editPair : edits)
+        for (const auto & editPair : edits)
             out << editPair.first.name() << std::endl;
     }
 
     static void dump(const Row &row, std::ostream &out)
     {
-        for (const auto& rowPair : row.cells())
+        for (const auto & rowPair : row.cells())
         {
             out << " + " << rowPair.second << " * ";
             dump(rowPair.first, out);
@@ -130,7 +130,7 @@ public:
 
     static void dump(const Constraint &cn, std::ostream &out)
     {
-        for (const auto& term : cn.expression().terms())
+        for (const auto & term : cn.expression().terms())
         {
             out << term.coefficient() << " * ";
             out << term.variable().name() << " + ";

--- a/kiwi/debug.h
+++ b/kiwi/debug.h
@@ -54,7 +54,7 @@ public:
 
     static void dump(const SolverImpl::RowMap &rows, std::ostream &out)
     {
-        for (const auto & rowPair : rows)
+        for (const auto &rowPair : rows)
         {
             dump(rowPair.first, out);
             out << " | ";
@@ -64,7 +64,7 @@ public:
 
     static void dump(const std::vector<Symbol> &symbols, std::ostream &out)
     {
-        for (const auto & symbol : symbols)
+        for (const auto &symbol : symbols)
         {
             dump(symbol, out);
             out << std::endl;
@@ -73,7 +73,7 @@ public:
 
     static void dump(const SolverImpl::VarMap &vars, std::ostream &out)
     {
-        for (const auto & varPair : vars)
+        for (const auto &varPair : vars)
         {
             out << varPair.first.name() << " = ";
             dump(varPair.second, out);
@@ -83,19 +83,19 @@ public:
 
     static void dump(const SolverImpl::CnMap &cns, std::ostream &out)
     {
-        for (const auto & cnPair : cns)
+        for (const auto &cnPair : cns)
             dump(cnPair.first, out);
     }
 
     static void dump(const SolverImpl::EditMap &edits, std::ostream &out)
     {
-        for (const auto & editPair : edits)
+        for (const auto &editPair : edits)
             out << editPair.first.name() << std::endl;
     }
 
     static void dump(const Row &row, std::ostream &out)
     {
-        for (const auto & rowPair : row.cells())
+        for (const auto &rowPair : row.cells())
         {
             out << " + " << rowPair.second << " * ";
             dump(rowPair.first, out);
@@ -130,7 +130,7 @@ public:
 
     static void dump(const Constraint &cn, std::ostream &out)
     {
-        for (const auto & term : cn.expression().terms())
+        for (const auto &term : cn.expression().terms())
         {
             out << term.coefficient() << " * ";
             out << term.variable().name() << " + ";

--- a/kiwi/errors.h
+++ b/kiwi/errors.h
@@ -20,9 +20,9 @@ class UnsatisfiableConstraint : public std::exception
 public:
     UnsatisfiableConstraint(const Constraint &constraint) : m_constraint(constraint) {}
 
-    ~UnsatisfiableConstraint() throw() {}
+    ~UnsatisfiableConstraint() noexcept {}
 
-    const char *what() const throw()
+    const char *what() const noexcept
     {
         return "The constraint can not be satisfied.";
     }
@@ -42,9 +42,9 @@ class UnknownConstraint : public std::exception
 public:
     UnknownConstraint(const Constraint &constraint) : m_constraint(constraint) {}
 
-    ~UnknownConstraint() throw() {}
+    ~UnknownConstraint() noexcept {}
 
-    const char *what() const throw()
+    const char *what() const noexcept
     {
         return "The constraint has not been added to the solver.";
     }
@@ -64,9 +64,9 @@ class DuplicateConstraint : public std::exception
 public:
     DuplicateConstraint(const Constraint &constraint) : m_constraint(constraint) {}
 
-    ~DuplicateConstraint() throw() {}
+    ~DuplicateConstraint() noexcept {}
 
-    const char *what() const throw()
+    const char *what() const noexcept
     {
         return "The constraint has already been added to the solver.";
     }
@@ -86,9 +86,9 @@ class UnknownEditVariable : public std::exception
 public:
     UnknownEditVariable(const Variable &variable) : m_variable(variable) {}
 
-    ~UnknownEditVariable() throw() {}
+    ~UnknownEditVariable() noexcept {}
 
-    const char *what() const throw()
+    const char *what() const noexcept
     {
         return "The edit variable has not been added to the solver.";
     }
@@ -108,9 +108,9 @@ class DuplicateEditVariable : public std::exception
 public:
     DuplicateEditVariable(const Variable &variable) : m_variable(variable) {}
 
-    ~DuplicateEditVariable() throw() {}
+    ~DuplicateEditVariable() noexcept {}
 
-    const char *what() const throw()
+    const char *what() const noexcept
     {
         return "The edit variable has already been added to the solver.";
     }
@@ -130,9 +130,9 @@ class BadRequiredStrength : public std::exception
 public:
     BadRequiredStrength() {}
 
-    ~BadRequiredStrength() throw() {}
+    ~BadRequiredStrength() noexcept {}
 
-    const char *what() const throw()
+    const char *what() const noexcept
     {
         return "A required strength cannot be used in this context.";
     }
@@ -148,9 +148,9 @@ public:
 
     InternalSolverError(const std::string &msg) : m_msg(msg) {}
 
-    ~InternalSolverError() throw() {}
+    ~InternalSolverError() noexcept {}
 
-    const char *what() const throw()
+    const char *what() const noexcept
     {
         return m_msg.c_str();
     }

--- a/kiwi/expression.h
+++ b/kiwi/expression.h
@@ -38,7 +38,7 @@ public:
     {
         double result = m_constant;
 
-        for (const Term& term : m_terms)
+        for (const Term &term : m_terms)
             result += term.value();
 
         return result;

--- a/kiwi/expression.h
+++ b/kiwi/expression.h
@@ -36,11 +36,11 @@ public:
 
     double value() const
     {
-        typedef std::vector<Term>::const_iterator iter_t;
         double result = m_constant;
-        iter_t end = m_terms.end();
-        for (iter_t it = m_terms.begin(); it != end; ++it)
-            result += it->value();
+
+        for (const Term& term : m_terms)
+            result += term.value();
+
         return result;
     }
 

--- a/kiwi/row.h
+++ b/kiwi/row.h
@@ -20,7 +20,7 @@ class Row
 {
 
 public:
-    typedef MapType<Symbol, double> CellMap;
+    using CellMap = MapType<Symbol, double>;
 
     Row() : m_constant(0.0) {}
 
@@ -28,7 +28,7 @@ public:
 
     Row(const Row &other) : m_cells(other.m_cells), m_constant(other.m_constant) {}
 
-    ~Row() {}
+    ~Row() = default;
 
     const CellMap &cells() const
     {
@@ -72,14 +72,13 @@ public:
 	*/
     void insert(const Row &other, double coefficient = 1.0)
     {
-        typedef CellMap::const_iterator iter_t;
         m_constant += other.m_constant * coefficient;
-        iter_t end = other.m_cells.end();
-        for (iter_t it = other.m_cells.begin(); it != end; ++it)
+
+        for (const auto& cellPair : other.m_cells)
         {
-            double coeff = it->second * coefficient;
-            if (nearZero(m_cells[it->first] += coeff))
-                m_cells.erase(it->first);
+            double coeff = cellPair.second * coefficient;
+            if (nearZero(m_cells[cellPair.first] += coeff))
+                m_cells.erase(cellPair.first);
         }
     }
 
@@ -88,7 +87,7 @@ public:
 	*/
     void remove(const Symbol &symbol)
     {
-        CellMap::iterator it = m_cells.find(symbol);
+        auto it = m_cells.find(symbol);
         if (it != m_cells.end())
             m_cells.erase(it);
     }
@@ -98,11 +97,9 @@ public:
 	*/
     void reverseSign()
     {
-        typedef CellMap::iterator iter_t;
         m_constant = -m_constant;
-        iter_t end = m_cells.end();
-        for (iter_t it = m_cells.begin(); it != end; ++it)
-            it->second = -it->second;
+        for (auto& cellPair : m_cells)
+            cellPair.second = -cellPair.second;
     }
 
     /* Solve the row for the given symbol.
@@ -118,13 +115,11 @@ public:
 	*/
     void solveFor(const Symbol &symbol)
     {
-        typedef CellMap::iterator iter_t;
         double coeff = -1.0 / m_cells[symbol];
         m_cells.erase(symbol);
         m_constant *= coeff;
-        iter_t end = m_cells.end();
-        for (iter_t it = m_cells.begin(); it != end; ++it)
-            it->second *= coeff;
+        for (auto& cellPair : m_cells)
+            cellPair.second *= coeff;
     }
 
     /* Solve the row for the given symbols.
@@ -168,8 +163,7 @@ public:
 	*/
     void substitute(const Symbol &symbol, const Row &row)
     {
-        typedef CellMap::iterator iter_t;
-        iter_t it = m_cells.find(symbol);
+        auto it = m_cells.find(symbol);
         if (it != m_cells.end())
         {
             double coefficient = it->second;

--- a/kiwi/row.h
+++ b/kiwi/row.h
@@ -87,7 +87,7 @@ public:
 	*/
     void remove(const Symbol &symbol)
     {
-        auto it = m_cells.find(symbol);
+        CellMap::iterator it = m_cells.find(symbol);
         if (it != m_cells.end())
             m_cells.erase(it);
     }
@@ -163,7 +163,7 @@ public:
 	*/
     void substitute(const Symbol &symbol, const Row &row)
     {
-        auto it = m_cells.find(symbol);
+        CellMap::iterator it = m_cells.find(symbol);
         if (it != m_cells.end())
         {
             double coefficient = it->second;

--- a/kiwi/row.h
+++ b/kiwi/row.h
@@ -74,7 +74,7 @@ public:
     {
         m_constant += other.m_constant * coefficient;
 
-        for (const auto& cellPair : other.m_cells)
+        for (const auto & cellPair : other.m_cells)
         {
             double coeff = cellPair.second * coefficient;
             if (nearZero(m_cells[cellPair.first] += coeff))

--- a/kiwi/row.h
+++ b/kiwi/row.h
@@ -87,7 +87,7 @@ public:
 	*/
     void remove(const Symbol &symbol)
     {
-        CellMap::iterator it = m_cells.find(symbol);
+        auto it = m_cells.find(symbol);
         if (it != m_cells.end())
             m_cells.erase(it);
     }
@@ -163,7 +163,7 @@ public:
 	*/
     void substitute(const Symbol &symbol, const Row &row)
     {
-        CellMap::iterator it = m_cells.find(symbol);
+        auto it = m_cells.find(symbol);
         if (it != m_cells.end())
         {
             double coefficient = it->second;

--- a/kiwi/row.h
+++ b/kiwi/row.h
@@ -22,11 +22,11 @@ class Row
 public:
     using CellMap = MapType<Symbol, double>;
 
-    Row() : m_constant(0.0) {}
+    Row() : Row(0.0) {}
 
     Row(double constant) : m_constant(constant) {}
 
-    Row(const Row &other) : m_cells(other.m_cells), m_constant(other.m_constant) {}
+    Row(const Row &other) = default;
 
     ~Row() = default;
 

--- a/kiwi/row.h
+++ b/kiwi/row.h
@@ -98,7 +98,7 @@ public:
     void reverseSign()
     {
         m_constant = -m_constant;
-        for (auto& cellPair : m_cells)
+        for (auto &cellPair : m_cells)
             cellPair.second = -cellPair.second;
     }
 
@@ -118,7 +118,7 @@ public:
         double coeff = -1.0 / m_cells[symbol];
         m_cells.erase(symbol);
         m_constant *= coeff;
-        for (auto& cellPair : m_cells)
+        for (auto &cellPair : m_cells)
             cellPair.second *= coeff;
     }
 

--- a/kiwi/shareddata.h
+++ b/kiwi/shareddata.h
@@ -16,12 +16,15 @@ class SharedData
 public:
     SharedData() : m_refcount(0) {}
 
-    SharedData(const SharedData &other) : m_refcount(0) {}
+    SharedData(const SharedData &other) = delete;
+
+    SharedData(SharedData&& other) = delete;
 
     int m_refcount;
 
-private:
-    SharedData &operator=(const SharedData &other);
+    SharedData &operator=(const SharedData &other) = delete;
+    
+    SharedData &operator=(SharedData&& other) = delete;
 };
 
 template <typename T>
@@ -29,9 +32,9 @@ class SharedDataPtr
 {
 
 public:
-    typedef T Type;
+    using Type = T;
 
-    SharedDataPtr() : m_data(0) {}
+    SharedDataPtr() : m_data(nullptr) {}
 
     explicit SharedDataPtr(T *data) : m_data(data)
     {

--- a/kiwi/solver.h
+++ b/kiwi/solver.h
@@ -21,7 +21,7 @@ class Solver
 
 public:
 
-	Solver() {}
+	Solver() = default;
 
 	~Solver() = default;
 

--- a/kiwi/solver.h
+++ b/kiwi/solver.h
@@ -23,7 +23,7 @@ public:
 
 	Solver() {}
 
-	~Solver() {}
+	~Solver() = default;
 
 	/* Add a constraint to the solver.
 

--- a/kiwi/solverimpl.h
+++ b/kiwi/solverimpl.h
@@ -44,13 +44,13 @@ class SolverImpl
 		double constant;
 	};
 
-	typedef MapType<Variable, Symbol> VarMap;
+	using VarMap = MapType<Variable, Symbol>;
 
-	typedef MapType<Symbol, Row*> RowMap;
+	using RowMap = MapType<Symbol, Row*>;
 
-	typedef MapType<Constraint, Tag> CnMap;
+	using CnMap = MapType<Constraint, Tag>;
 
-	typedef MapType<Variable, EditInfo> EditMap;
+	using EditMap = MapType<Variable, EditInfo>;
 
 	struct DualOptimizeGuard
 	{
@@ -62,6 +62,10 @@ class SolverImpl
 public:
 
 	SolverImpl() : m_objective( new Row() ), m_id_tick( 1 ) {}
+
+	SolverImpl( const SolverImpl& ) = delete;
+
+	SolverImpl( SolverImpl&& ) = delete;
 
 	~SolverImpl() { clearRows(); }
 
@@ -138,7 +142,7 @@ public:
 	*/
 	void removeConstraint( const Constraint& constraint )
 	{
-		CnMap::iterator cn_it = m_cns.find( constraint );
+		auto cn_it = m_cns.find( constraint );
 		if( cn_it == m_cns.end() )
 			throw UnknownConstraint( constraint );
 
@@ -152,7 +156,7 @@ public:
 
 		// If the marker is basic, simply drop the row. Otherwise,
 		// pivot the marker into the basis and then drop the row.
-		RowMap::iterator row_it = m_rows.find( tag.marker );
+		auto row_it = m_rows.find( tag.marker );
 		if( row_it != m_rows.end() )
 		{
 			std::unique_ptr<Row> rowptr( row_it->second );
@@ -224,7 +228,7 @@ public:
 	*/
 	void removeEditVariable( const Variable& variable )
 	{
-		EditMap::iterator it = m_edits.find( variable );
+		auto it = m_edits.find( variable );
 		if( it == m_edits.end() )
 			throw UnknownEditVariable( variable );
 		removeConstraint( it->second.constraint );
@@ -252,7 +256,7 @@ public:
 	*/
 	void suggestValue( const Variable& variable, double value )
 	{
-		EditMap::iterator it = m_edits.find( variable );
+		auto it = m_edits.find( variable );
 		if( it == m_edits.end() )
 			throw UnknownEditVariable( variable );
 
@@ -262,7 +266,7 @@ public:
 		info.constant = value;
 
 		// Check first if the positive error variable is basic.
-		RowMap::iterator row_it = m_rows.find( info.tag.marker );
+		auto row_it = m_rows.find( info.tag.marker );
 		if( row_it != m_rows.end() )
 		{
 			if( row_it->second->add( -delta ) < 0.0 )
@@ -280,14 +284,13 @@ public:
 		}
 
 		// Otherwise update each row where the error variables exist.
-		RowMap::iterator end = m_rows.end();
-		for( row_it = m_rows.begin(); row_it != end; ++row_it )
+		for (const auto& rowPair : m_rows)
 		{
-			double coeff = row_it->second->coefficientFor( info.tag.marker );
+			double coeff = rowPair.second->coefficientFor( info.tag.marker );
 			if( coeff != 0.0 &&
-				row_it->second->add( delta * coeff ) < 0.0 &&
-				row_it->first.type() != Symbol::External )
-				m_infeasible_rows.push_back( row_it->first );
+				rowPair.second->add( delta * coeff ) < 0.0 &&
+				rowPair.first.type() != Symbol::External )
+				m_infeasible_rows.push_back( rowPair.first );
 		}
 	}
 
@@ -296,14 +299,12 @@ public:
 	*/
 	void updateVariables()
 	{
-		typedef RowMap::iterator row_iter_t;
-		typedef VarMap::iterator var_iter_t;
-		row_iter_t row_end = m_rows.end();
-		var_iter_t var_end = m_vars.end();
-		for( var_iter_t var_it = m_vars.begin(); var_it != var_end; ++var_it )
+		auto row_end = m_rows.end();
+
+		for (auto& varPair : m_vars)
 		{
-			Variable& var( const_cast<Variable&>( var_it->first ) );
-			row_iter_t row_it = m_rows.find( var_it->second );
+			Variable& var = varPair.first;
+			auto row_it = m_rows.find( varPair.second );
 			if( row_it == row_end )
 				var.setValue( 0.0 );
 			else
@@ -332,11 +333,11 @@ public:
 		m_id_tick = 1;
 	}
 
+	SolverImpl& operator=( const SolverImpl& ) = delete;
+
+	SolverImpl& operator=( SolverImpl&& ) = delete;
+
 private:
-
-	SolverImpl( const SolverImpl& );
-
-	SolverImpl& operator=( const SolverImpl& );
 
 	struct RowDeleter
 	{
@@ -357,7 +358,7 @@ private:
 	*/
 	Symbol getVarSymbol( const Variable& variable )
 	{
-		VarMap::iterator it = m_vars.find( variable );
+		auto it = m_vars.find( variable );
 		if( it != m_vars.end() )
 			return it->second;
 		Symbol symbol( Symbol::External, m_id_tick++ );
@@ -382,24 +383,22 @@ private:
 	for tracking the movement of the constraint in the tableau.
 
 	*/
-	Row* createRow( const Constraint& constraint, Tag& tag )
+	std::unique_ptr<Row> createRow( const Constraint& constraint, Tag& tag )
 	{
-		typedef std::vector<Term>::const_iterator iter_t;
 		const Expression& expr( constraint.expression() );
-		Row* row = new Row( expr.constant() );
+		std::unique_ptr<Row> row( new Row( expr.constant() ) );
 
 		// Substitute the current basic variables into the row.
-		iter_t end = expr.terms().end();
-		for( iter_t it = expr.terms().begin(); it != end; ++it )
+		for (const auto& term : expr.terms())
 		{
-			if( !nearZero( it->coefficient() ) )
+			if( !nearZero( term.coefficient() ) )
 			{
-				Symbol symbol( getVarSymbol( it->variable() ) );
-				RowMap::const_iterator row_it = m_rows.find( symbol );
+				Symbol symbol( getVarSymbol( term.variable() ) );
+				auto row_it = m_rows.find( symbol );
 				if( row_it != m_rows.end() )
-					row->insert( *row_it->second, it->coefficient() );
+					row->insert( *row_it->second, term.coefficient() );
 				else
-					row->insert( symbol, it->coefficient() );
+					row->insert( symbol, term.coefficient() );
 			}
 		}
 
@@ -466,14 +465,12 @@ private:
 	If a subject cannot be found, an invalid symbol will be returned.
 
 	*/
-	Symbol chooseSubject( const Row& row, const Tag& tag )
+	Symbol chooseSubject( const Row& row, const Tag& tag ) const
 	{
-		typedef Row::CellMap::const_iterator iter_t;
-		iter_t end = row.cells().end();
-		for( iter_t it = row.cells().begin(); it != end; ++it )
+		for (const auto& cellPair : row.cells())
 		{
-			if( it->first.type() == Symbol::External )
-				return it->first;
+			if( cellPair.first.type() == Symbol::External )
+				return cellPair.first;
 		}
 		if( tag.marker.type() == Symbol::Slack || tag.marker.type() == Symbol::Error )
 		{
@@ -508,7 +505,7 @@ private:
 
 		// If the artificial variable is not basic, pivot the row so that
 		// it becomes basic. If the row is constant, exit early.
-		RowMap::iterator it = m_rows.find( art );
+		auto it = m_rows.find( art );
 		if( it != m_rows.end() )
 		{
 			std::unique_ptr<Row> rowptr( it->second );
@@ -524,9 +521,9 @@ private:
 		}
 
 		// Remove the artificial variable from the tableau.
-		RowMap::iterator end = m_rows.end();
-		for( it = m_rows.begin(); it != end; ++it )
-			it->second->remove( art );
+		for (auto& rowPair : m_rows)
+			rowPair.second->remove(art);
+
 		m_objective->remove( art );
 		return success;
  	}
@@ -539,14 +536,12 @@ private:
 	*/
 	void substitute( const Symbol& symbol, const Row& row )
 	{
-		typedef RowMap::iterator iter_t;
-		iter_t end = m_rows.end();
-		for( iter_t it = m_rows.begin(); it != end; ++it )
+		for( auto& rowPair : m_rows )
 		{
-			it->second->substitute( symbol, row );
-			if( it->first.type() != Symbol::External &&
-				it->second->constant() < 0.0 )
-				m_infeasible_rows.push_back( it->first );
+			rowPair.second->substitute( symbol, row );
+			if( rowPair.first.type() != Symbol::External &&
+				rowPair.second->constant() < 0.0 )
+				m_infeasible_rows.push_back( rowPair.first );
 		}
 		m_objective->substitute( symbol, row );
 		if( m_artificial.get() )
@@ -571,7 +566,7 @@ private:
 			Symbol entering( getEnteringSymbol( objective ) );
 			if( entering.type() == Symbol::Invalid )
 				return;
-			RowMap::iterator it = getLeavingRow( entering );
+			auto it = getLeavingRow( entering );
 			if( it == m_rows.end() )
 				throw InternalSolverError( "The objective is unbounded." );
 			// pivot the entering symbol into the basis
@@ -604,7 +599,7 @@ private:
 
 			Symbol leaving( m_infeasible_rows.back() );
 			m_infeasible_rows.pop_back();
-			RowMap::iterator it = m_rows.find( leaving );
+			auto it = m_rows.find( leaving );
 			if( it != m_rows.end() && !nearZero( it->second->constant() ) &&
 				it->second->constant() < 0.0 )
 			{
@@ -629,14 +624,12 @@ private:
 	invalid symbol is returned.
 
 	*/
-	Symbol getEnteringSymbol( const Row& objective )
+	Symbol getEnteringSymbol( const Row& objective ) const
 	{
-		typedef Row::CellMap::const_iterator iter_t;
-		iter_t end = objective.cells().end();
-		for( iter_t it = objective.cells().begin(); it != end; ++it )
+		for (const auto& cellPair : objective.cells())
 		{
-			if( it->first.type() != Symbol::Dummy && it->second < 0.0 )
-				return it->first;
+			if( cellPair.first.type() != Symbol::Dummy && cellPair.second < 0.0 )
+				return cellPair.first;
 		}
 		return Symbol();
 	}
@@ -650,22 +643,20 @@ private:
 	is returned.
 
 	*/
-	Symbol getDualEnteringSymbol( const Row& row )
+	Symbol getDualEnteringSymbol( const Row& row ) const
 	{
-		typedef Row::CellMap::const_iterator iter_t;
 		Symbol entering;
 		double ratio = std::numeric_limits<double>::max();
-		iter_t end = row.cells().end();
-		for( iter_t it = row.cells().begin(); it != end; ++it )
+		for (const auto& cellPair : row.cells())
 		{
-			if( it->second > 0.0 && it->first.type() != Symbol::Dummy )
+			if( cellPair.second > 0.0 && cellPair.first.type() != Symbol::Dummy )
 			{
-				double coeff = m_objective->coefficientFor( it->first );
-				double r = coeff / it->second;
+				double coeff = m_objective->coefficientFor( cellPair.first );
+				double r = coeff / cellPair.second;
 				if( r < ratio )
 				{
 					ratio = r;
-					entering = it->first;
+					entering = cellPair.first;
 				}
 			}
 		}
@@ -677,13 +668,11 @@ private:
 	If no such symbol is present, and Invalid symbol will be returned.
 
 	*/
-	Symbol anyPivotableSymbol( const Row& row )
+	Symbol anyPivotableSymbol( const Row& row ) const
 	{
-		typedef Row::CellMap::const_iterator iter_t;
-		iter_t end = row.cells().end();
-		for( iter_t it = row.cells().begin(); it != end; ++it )
+		for (const auto& cellPair : row.cells())
 		{
-			const Symbol& sym( it->first );
+			const Symbol& sym( cellPair.first );
 			if( sym.type() == Symbol::Slack || sym.type() == Symbol::Error )
 				return sym;
 		}
@@ -700,11 +689,10 @@ private:
 	*/
 	RowMap::iterator getLeavingRow( const Symbol& entering )
 	{
-		typedef RowMap::iterator iter_t;
 		double ratio = std::numeric_limits<double>::max();
-		iter_t end = m_rows.end();
-		iter_t found = m_rows.end();
-		for( iter_t it = m_rows.begin(); it != end; ++it )
+		auto end = m_rows.end();
+		auto found = m_rows.end();
+		for( auto it = m_rows.begin(); it != end; ++it )
 		{
 			if( it->first.type() != Symbol::External )
 			{
@@ -745,14 +733,13 @@ private:
 	RowMap::iterator getMarkerLeavingRow( const Symbol& marker )
 	{
 		const double dmax = std::numeric_limits<double>::max();
-		typedef RowMap::iterator iter_t;
 		double r1 = dmax;
 		double r2 = dmax;
-		iter_t end = m_rows.end();
-		iter_t first = end;
-		iter_t second = end;
-		iter_t third = end;
-		for( iter_t it = m_rows.begin(); it != end; ++it )
+		auto end = m_rows.end();
+		auto first = end;
+		auto second = end;
+		auto third = end;
+		for( auto it = m_rows.begin(); it != end; ++it )
 		{
 			double c = it->second->coefficientFor( marker );
 			if( c == 0.0 )
@@ -803,7 +790,7 @@ private:
 	*/
 	void removeMarkerEffects( const Symbol& marker, double strength )
 	{
-		RowMap::iterator row_it = m_rows.find( marker );
+		auto row_it = m_rows.find( marker );
 		if( row_it != m_rows.end() )
 			m_objective->insert( *row_it->second, -strength );
 		else
@@ -813,13 +800,11 @@ private:
 	/* Test whether a row is composed of all dummy variables.
 
 	*/
-	bool allDummies( const Row& row )
+	bool allDummies( const Row& row ) const
 	{
-		typedef Row::CellMap::const_iterator iter_t;
-		iter_t end = row.cells().end();
-		for( iter_t it = row.cells().begin(); it != end; ++it )
+		for (const auto& rowPair : row.cells())
 		{
-			if( it->first.type() != Symbol::Dummy )
+			if( rowPair.first.type() != Symbol::Dummy )
 				return false;
 		}
 		return true;

--- a/kiwi/solverimpl.h
+++ b/kiwi/solverimpl.h
@@ -142,7 +142,7 @@ public:
 	*/
 	void removeConstraint( const Constraint& constraint )
 	{
-		CnMap::iterator cn_it = m_cns.find( constraint );
+		auto cn_it = m_cns.find( constraint );
 		if( cn_it == m_cns.end() )
 			throw UnknownConstraint( constraint );
 
@@ -156,7 +156,7 @@ public:
 
 		// If the marker is basic, simply drop the row. Otherwise,
 		// pivot the marker into the basis and then drop the row.
-		RowMap::iterator row_it = m_rows.find( tag.marker );
+		auto row_it = m_rows.find( tag.marker );
 		if( row_it != m_rows.end() )
 		{
 			std::unique_ptr<Row> rowptr( row_it->second );
@@ -228,7 +228,7 @@ public:
 	*/
 	void removeEditVariable( const Variable& variable )
 	{
-		EditMap::iterator it = m_edits.find( variable );
+		auto it = m_edits.find( variable );
 		if( it == m_edits.end() )
 			throw UnknownEditVariable( variable );
 		removeConstraint( it->second.constraint );
@@ -256,7 +256,7 @@ public:
 	*/
 	void suggestValue( const Variable& variable, double value )
 	{
-		EditMap::iterator it = m_edits.find( variable );
+		auto it = m_edits.find( variable );
 		if( it == m_edits.end() )
 			throw UnknownEditVariable( variable );
 
@@ -266,7 +266,7 @@ public:
 		info.constant = value;
 
 		// Check first if the positive error variable is basic.
-		RowMap::iterator row_it = m_rows.find( info.tag.marker );
+		auto row_it = m_rows.find( info.tag.marker );
 		if( row_it != m_rows.end() )
 		{
 			if( row_it->second->add( -delta ) < 0.0 )
@@ -299,12 +299,12 @@ public:
 	*/
 	void updateVariables()
 	{
-		RowMap::iterator row_end = m_rows.end();
+		auto row_end = m_rows.end();
 
 		for (auto &varPair : m_vars)
 		{
 			Variable& var = varPair.first;
-			RowMap::iterator row_it = m_rows.find( varPair.second );
+			auto row_it = m_rows.find( varPair.second );
 			if( row_it == row_end )
 				var.setValue( 0.0 );
 			else
@@ -358,7 +358,7 @@ private:
 	*/
 	Symbol getVarSymbol( const Variable& variable )
 	{
-		VarMap::iterator it = m_vars.find( variable );
+		auto it = m_vars.find( variable );
 		if( it != m_vars.end() )
 			return it->second;
 		Symbol symbol( Symbol::External, m_id_tick++ );
@@ -394,7 +394,7 @@ private:
 			if( !nearZero( term.coefficient() ) )
 			{
 				Symbol symbol( getVarSymbol( term.variable() ) );
-				RowMap::iterator row_it = m_rows.find( symbol );
+				auto row_it = m_rows.find( symbol );
 				if( row_it != m_rows.end() )
 					row->insert( *row_it->second, term.coefficient() );
 				else
@@ -505,7 +505,7 @@ private:
 
 		// If the artificial variable is not basic, pivot the row so that
 		// it becomes basic. If the row is constant, exit early.
-		RowMap::iterator it = m_rows.find( art );
+		auto it = m_rows.find( art );
 		if( it != m_rows.end() )
 		{
 			std::unique_ptr<Row> rowptr( it->second );
@@ -566,7 +566,7 @@ private:
 			Symbol entering( getEnteringSymbol( objective ) );
 			if( entering.type() == Symbol::Invalid )
 				return;
-			RowMap::iterator it = getLeavingRow( entering );
+			auto it = getLeavingRow( entering );
 			if( it == m_rows.end() )
 				throw InternalSolverError( "The objective is unbounded." );
 			// pivot the entering symbol into the basis
@@ -599,7 +599,7 @@ private:
 
 			Symbol leaving( m_infeasible_rows.back() );
 			m_infeasible_rows.pop_back();
-			RowMap::iterator it = m_rows.find( leaving );
+			auto it = m_rows.find( leaving );
 			if( it != m_rows.end() && !nearZero( it->second->constant() ) &&
 				it->second->constant() < 0.0 )
 			{
@@ -690,9 +690,9 @@ private:
 	RowMap::iterator getLeavingRow( const Symbol& entering )
 	{
 		double ratio = std::numeric_limits<double>::max();
-		RowMap::iterator end = m_rows.end();
-		RowMap::iterator found = m_rows.end();
-		for( RowMap::iterator it = m_rows.begin(); it != end; ++it )
+		auto end = m_rows.end();
+		auto found = m_rows.end();
+		for( auto it = m_rows.begin(); it != end; ++it )
 		{
 			if( it->first.type() != Symbol::External )
 			{
@@ -735,11 +735,11 @@ private:
 		const double dmax = std::numeric_limits<double>::max();
 		double r1 = dmax;
 		double r2 = dmax;
-		RowMap::iterator end = m_rows.end();
-		RowMap::iterator first = end;
-		RowMap::iterator second = end;
-		RowMap::iterator third = end;
-		for( RowMap::iterator it = m_rows.begin(); it != end; ++it )
+		auto end = m_rows.end();
+		auto first = end;
+		auto second = end;
+		auto third = end;
+		for( auto it = m_rows.begin(); it != end; ++it )
 		{
 			double c = it->second->coefficientFor( marker );
 			if( c == 0.0 )
@@ -790,7 +790,7 @@ private:
 	*/
 	void removeMarkerEffects( const Symbol& marker, double strength )
 	{
-		RowMap::iterator row_it = m_rows.find( marker );
+		auto row_it = m_rows.find( marker );
 		if( row_it != m_rows.end() )
 			m_objective->insert( *row_it->second, -strength );
 		else

--- a/kiwi/solverimpl.h
+++ b/kiwi/solverimpl.h
@@ -142,7 +142,7 @@ public:
 	*/
 	void removeConstraint( const Constraint& constraint )
 	{
-		auto cn_it = m_cns.find( constraint );
+		CnMap::iterator cn_it = m_cns.find( constraint );
 		if( cn_it == m_cns.end() )
 			throw UnknownConstraint( constraint );
 
@@ -156,7 +156,7 @@ public:
 
 		// If the marker is basic, simply drop the row. Otherwise,
 		// pivot the marker into the basis and then drop the row.
-		auto row_it = m_rows.find( tag.marker );
+		RowMap::iterator row_it = m_rows.find( tag.marker );
 		if( row_it != m_rows.end() )
 		{
 			std::unique_ptr<Row> rowptr( row_it->second );
@@ -228,7 +228,7 @@ public:
 	*/
 	void removeEditVariable( const Variable& variable )
 	{
-		auto it = m_edits.find( variable );
+		EditMap::iterator it = m_edits.find( variable );
 		if( it == m_edits.end() )
 			throw UnknownEditVariable( variable );
 		removeConstraint( it->second.constraint );
@@ -256,7 +256,7 @@ public:
 	*/
 	void suggestValue( const Variable& variable, double value )
 	{
-		auto it = m_edits.find( variable );
+		EditMap::iterator it = m_edits.find( variable );
 		if( it == m_edits.end() )
 			throw UnknownEditVariable( variable );
 
@@ -266,7 +266,7 @@ public:
 		info.constant = value;
 
 		// Check first if the positive error variable is basic.
-		auto row_it = m_rows.find( info.tag.marker );
+		RowMap::iterator row_it = m_rows.find( info.tag.marker );
 		if( row_it != m_rows.end() )
 		{
 			if( row_it->second->add( -delta ) < 0.0 )
@@ -299,12 +299,12 @@ public:
 	*/
 	void updateVariables()
 	{
-		auto row_end = m_rows.end();
+		RowMap::iterator row_end = m_rows.end();
 
 		for (auto& varPair : m_vars)
 		{
 			Variable& var = varPair.first;
-			auto row_it = m_rows.find( varPair.second );
+			RowMap::iterator row_it = m_rows.find( varPair.second );
 			if( row_it == row_end )
 				var.setValue( 0.0 );
 			else
@@ -358,7 +358,7 @@ private:
 	*/
 	Symbol getVarSymbol( const Variable& variable )
 	{
-		auto it = m_vars.find( variable );
+		VarMap::iterator it = m_vars.find( variable );
 		if( it != m_vars.end() )
 			return it->second;
 		Symbol symbol( Symbol::External, m_id_tick++ );
@@ -394,7 +394,7 @@ private:
 			if( !nearZero( term.coefficient() ) )
 			{
 				Symbol symbol( getVarSymbol( term.variable() ) );
-				auto row_it = m_rows.find( symbol );
+				RowMap::iterator row_it = m_rows.find( symbol );
 				if( row_it != m_rows.end() )
 					row->insert( *row_it->second, term.coefficient() );
 				else
@@ -505,7 +505,7 @@ private:
 
 		// If the artificial variable is not basic, pivot the row so that
 		// it becomes basic. If the row is constant, exit early.
-		auto it = m_rows.find( art );
+		RowMap::iterator it = m_rows.find( art );
 		if( it != m_rows.end() )
 		{
 			std::unique_ptr<Row> rowptr( it->second );
@@ -566,7 +566,7 @@ private:
 			Symbol entering( getEnteringSymbol( objective ) );
 			if( entering.type() == Symbol::Invalid )
 				return;
-			auto it = getLeavingRow( entering );
+			RowMap::iterator it = getLeavingRow( entering );
 			if( it == m_rows.end() )
 				throw InternalSolverError( "The objective is unbounded." );
 			// pivot the entering symbol into the basis
@@ -599,7 +599,7 @@ private:
 
 			Symbol leaving( m_infeasible_rows.back() );
 			m_infeasible_rows.pop_back();
-			auto it = m_rows.find( leaving );
+			RowMap::iterator it = m_rows.find( leaving );
 			if( it != m_rows.end() && !nearZero( it->second->constant() ) &&
 				it->second->constant() < 0.0 )
 			{
@@ -690,9 +690,9 @@ private:
 	RowMap::iterator getLeavingRow( const Symbol& entering )
 	{
 		double ratio = std::numeric_limits<double>::max();
-		auto end = m_rows.end();
-		auto found = m_rows.end();
-		for( auto it = m_rows.begin(); it != end; ++it )
+		RowMap::iterator end = m_rows.end();
+		RowMap::iterator found = m_rows.end();
+		for( RowMap::iterator it = m_rows.begin(); it != end; ++it )
 		{
 			if( it->first.type() != Symbol::External )
 			{
@@ -735,11 +735,11 @@ private:
 		const double dmax = std::numeric_limits<double>::max();
 		double r1 = dmax;
 		double r2 = dmax;
-		auto end = m_rows.end();
-		auto first = end;
-		auto second = end;
-		auto third = end;
-		for( auto it = m_rows.begin(); it != end; ++it )
+		RowMap::iterator end = m_rows.end();
+		RowMap::iterator first = end;
+		RowMap::iterator second = end;
+		RowMap::iterator third = end;
+		for( RowMap::iterator it = m_rows.begin(); it != end; ++it )
 		{
 			double c = it->second->coefficientFor( marker );
 			if( c == 0.0 )
@@ -790,7 +790,7 @@ private:
 	*/
 	void removeMarkerEffects( const Symbol& marker, double strength )
 	{
-		auto row_it = m_rows.find( marker );
+		RowMap::iterator row_it = m_rows.find( marker );
 		if( row_it != m_rows.end() )
 			m_objective->insert( *row_it->second, -strength );
 		else

--- a/kiwi/solverimpl.h
+++ b/kiwi/solverimpl.h
@@ -284,7 +284,7 @@ public:
 		}
 
 		// Otherwise update each row where the error variables exist.
-		for (const auto& rowPair : m_rows)
+		for (const auto & rowPair : m_rows)
 		{
 			double coeff = rowPair.second->coefficientFor( info.tag.marker );
 			if( coeff != 0.0 &&
@@ -389,7 +389,7 @@ private:
 		std::unique_ptr<Row> row( new Row( expr.constant() ) );
 
 		// Substitute the current basic variables into the row.
-		for (const auto& term : expr.terms())
+		for (const auto & term : expr.terms())
 		{
 			if( !nearZero( term.coefficient() ) )
 			{
@@ -467,7 +467,7 @@ private:
 	*/
 	Symbol chooseSubject( const Row& row, const Tag& tag ) const
 	{
-		for (const auto& cellPair : row.cells())
+		for (const auto & cellPair : row.cells())
 		{
 			if( cellPair.first.type() == Symbol::External )
 				return cellPair.first;
@@ -626,7 +626,7 @@ private:
 	*/
 	Symbol getEnteringSymbol( const Row& objective ) const
 	{
-		for (const auto& cellPair : objective.cells())
+		for (const auto & cellPair : objective.cells())
 		{
 			if( cellPair.first.type() != Symbol::Dummy && cellPair.second < 0.0 )
 				return cellPair.first;
@@ -647,7 +647,7 @@ private:
 	{
 		Symbol entering;
 		double ratio = std::numeric_limits<double>::max();
-		for (const auto& cellPair : row.cells())
+		for (const auto & cellPair : row.cells())
 		{
 			if( cellPair.second > 0.0 && cellPair.first.type() != Symbol::Dummy )
 			{
@@ -670,7 +670,7 @@ private:
 	*/
 	Symbol anyPivotableSymbol( const Row& row ) const
 	{
-		for (const auto& cellPair : row.cells())
+		for (const auto & cellPair : row.cells())
 		{
 			const Symbol& sym( cellPair.first );
 			if( sym.type() == Symbol::Slack || sym.type() == Symbol::Error )
@@ -802,7 +802,7 @@ private:
 	*/
 	bool allDummies( const Row& row ) const
 	{
-		for (const auto& rowPair : row.cells())
+		for (const auto & rowPair : row.cells())
 		{
 			if( rowPair.first.type() != Symbol::Dummy )
 				return false;

--- a/kiwi/solverimpl.h
+++ b/kiwi/solverimpl.h
@@ -301,7 +301,7 @@ public:
 	{
 		RowMap::iterator row_end = m_rows.end();
 
-		for (auto& varPair : m_vars)
+		for (auto &varPair : m_vars)
 		{
 			Variable& var = varPair.first;
 			RowMap::iterator row_it = m_rows.find( varPair.second );
@@ -389,7 +389,7 @@ private:
 		std::unique_ptr<Row> row( new Row( expr.constant() ) );
 
 		// Substitute the current basic variables into the row.
-		for (const auto & term : expr.terms())
+		for (const auto &term : expr.terms())
 		{
 			if( !nearZero( term.coefficient() ) )
 			{
@@ -467,7 +467,7 @@ private:
 	*/
 	Symbol chooseSubject( const Row& row, const Tag& tag ) const
 	{
-		for (const auto & cellPair : row.cells())
+		for (const auto &cellPair : row.cells())
 		{
 			if( cellPair.first.type() == Symbol::External )
 				return cellPair.first;
@@ -521,7 +521,7 @@ private:
 		}
 
 		// Remove the artificial variable from the tableau.
-		for (auto& rowPair : m_rows)
+		for (auto &rowPair : m_rows)
 			rowPair.second->remove(art);
 
 		m_objective->remove( art );
@@ -626,7 +626,7 @@ private:
 	*/
 	Symbol getEnteringSymbol( const Row& objective ) const
 	{
-		for (const auto & cellPair : objective.cells())
+		for (const auto &cellPair : objective.cells())
 		{
 			if( cellPair.first.type() != Symbol::Dummy && cellPair.second < 0.0 )
 				return cellPair.first;
@@ -647,7 +647,7 @@ private:
 	{
 		Symbol entering;
 		double ratio = std::numeric_limits<double>::max();
-		for (const auto & cellPair : row.cells())
+		for (const auto &cellPair : row.cells())
 		{
 			if( cellPair.second > 0.0 && cellPair.first.type() != Symbol::Dummy )
 			{
@@ -670,7 +670,7 @@ private:
 	*/
 	Symbol anyPivotableSymbol( const Row& row ) const
 	{
-		for (const auto & cellPair : row.cells())
+		for (const auto &cellPair : row.cells())
 		{
 			const Symbol& sym( cellPair.first );
 			if( sym.type() == Symbol::Slack || sym.type() == Symbol::Error )
@@ -802,7 +802,7 @@ private:
 	*/
 	bool allDummies( const Row& row ) const
 	{
-		for (const auto & rowPair : row.cells())
+		for (const auto &rowPair : row.cells())
 		{
 			if( rowPair.first.type() != Symbol::Dummy )
 				return false;

--- a/kiwi/symbol.h
+++ b/kiwi/symbol.h
@@ -19,7 +19,7 @@ class Symbol
 
 public:
 
-	typedef unsigned long long Id;
+	using Id = unsigned long long;
 
 	enum Type
 	{
@@ -34,7 +34,7 @@ public:
 
 	Symbol( Type type, Id id ) : m_id( id ), m_type( type ) {}
 
-	~Symbol() {}
+	~Symbol() = default;
 
 	Id id() const
 	{

--- a/kiwi/symbolics.h
+++ b/kiwi/symbolics.h
@@ -69,12 +69,11 @@ Expression operator*( const Expression& expression, double coefficient )
 {
 	std::vector<Term> terms;
 	terms.reserve( expression.terms().size() );
-	typedef std::vector<Term>::const_iterator iter_t;
-	iter_t begin = expression.terms().begin();
-	iter_t end = expression.terms().end();
-	for( iter_t it = begin; it != end; ++it )
-		terms.push_back( ( *it ) * coefficient );
-	return Expression( terms, expression.constant() * coefficient );
+
+	for (const Term& term : expression.terms())
+		terms.push_back(term * coefficient);
+
+	return Expression( std::move(terms), expression.constant() * coefficient );
 }
 
 
@@ -193,11 +192,7 @@ Expression operator+( const Term& term, const Expression& expression )
 inline
 Expression operator+( const Term& first, const Term& second )
 {
-	std::vector<Term> terms;
-	terms.reserve( 2 );
-	terms.push_back( first );
-	terms.push_back( second );
-	return Expression( terms );
+	return Expression( { first, second } );
 }
 
 

--- a/kiwi/symbolics.h
+++ b/kiwi/symbolics.h
@@ -70,7 +70,7 @@ Expression operator*( const Expression& expression, double coefficient )
 	std::vector<Term> terms;
 	terms.reserve( expression.terms().size() );
 
-	for (const Term& term : expression.terms())
+	for (const Term &term : expression.terms())
 		terms.push_back(term * coefficient);
 
 	return Expression( std::move(terms), expression.constant() * coefficient );

--- a/kiwi/variable.h
+++ b/kiwi/variable.h
@@ -20,7 +20,7 @@ public:
     class Context
     {
     public:
-        Context() {}
+        Context() = default;
         virtual ~Context() {} // LCOV_EXCL_LINE
     };
 


### PR DESCRIPTION
Please note this is a follow-up on #89.

This PR aims to make C++11 more idiomatic, replacing typedefs by using/auto and regular loops by for-range loops when possible.

It also replaces throw() expression by noexcept, empty constructor/destructor by default ones and such