### PR TITLE
Add license trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
     license='BSD',
     classifiers=[
           # https://pypi.org/pypi?%3Aaction=list_classifiers
+          'License :: OSI Approved :: BSD License',
           'Programming Language :: Python',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Tools such as [`pip-licenses`](https://pypi.org/project/pip-licenses/) use the license information that is included as part of the package to generate license reports. The canonical location for this license information is in a fully qualified License trove classifier.

This PR corrects the trove classifier to fully qualify it, so that this package can be properly categorized with other BSD-licensed packages when generating license reports.