### PR TITLE
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ jobs:
   - name: "run test suite with python 3.8 on ARM64"
     arch: arm64
     python: 3.8
-  - name: "run test suite with python 3.9 on ARM64"
-    arch: arm64
-    python: 3.9
+  # ARM currently does not have 3.9, should add it later
 
   # added power support ppc64le arch
   - name: "run test suite with python 3.6 on PPC64le"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,9 @@ jobs:
   - name: "run test suite with python 3.8 on PPC64le"
     arch: ppc64le
     python: 3.8
-    arch: ppc64le
   - name: "run test suite with python 3.9 on PPC64le"
     arch: ppc64le
     python: 3.9
-    arch: ppc64le
 
 env:
   - CPPFLAGS=--coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,17 +25,24 @@ jobs:
   - name: "run test suite with python 3.8 on ARM64"
     arch: arm64
     python: 3.8
+  - name: "run test suite with python 3.9 on ARM64"
+    arch: arm64
+    python: 3.9
 
   # added power support ppc64le arch
-  - name: "run test suite with python 3.6 on ARM64"
+  - name: "run test suite with python 3.6 on PPC64le"
     arch: ppc64le
     python: 3.6
-  - name: "run test suite with python 3.7 on ARM64"
+  - name: "run test suite with python 3.7 on PPC64le"
     arch: ppc64le
     python: 3.7
-  - name: "run test suite with python 3.8 on ARM64"
+  - name: "run test suite with python 3.8 on PPC64le"
     arch: ppc64le
     python: 3.8
+    arch: ppc64le
+  - name: "run test suite with python 3.9 on PPC64le"
+    arch: ppc64le
+    python: 3.9
     arch: ppc64le
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ jobs:
     arch: arm64
     python: 3.8
 
-env:
-  - CPPFLAGS=--coverage
   # added power support ppc64le arch
   - name: "run test suite with python 3.6 on ARM64"
     arch: ppc64le

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,20 @@ jobs:
 
 env:
   - CPPFLAGS=--coverage
+  # added power support ppc64le arch
+  - name: "run test suite with python 3.6 on ARM64"
+    arch: ppc64le
+    python: 3.6
+  - name: "run test suite with python 3.7 on ARM64"
+    arch: ppc64le
+    python: 3.7
+  - name: "run test suite with python 3.8 on ARM64"
+    arch: ppc64le
+    python: 3.8
+    arch: ppc64le
+
+env:
+  - CPPFLAGS=--coverage
 before_install:
   - pip install --upgrade pip
   - pip install https://github.com/nucleic/cppy/tarball/master


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

