### PR TITLE
docs: fix typos

### DIFF
--- a/docs/source/basis/basic_systems.rst
+++ b/docs/source/basis/basic_systems.rst
@@ -5,7 +5,7 @@ Constraints definition and system solving
 
 .. include:: ../substitutions.sub
 
-A system in Kiwi is defined by a set of contraints that can be either
+A system in Kiwi is defined by a set of constraints that can be either
 equalities or inequalities (>= and <= only, strict inequalities are not
 accepted), each of which can have an associated strength making more or less
 important to respect when solving the problem. The next sections will cover how

--- a/docs/source/basis/solver_internals.rst
+++ b/docs/source/basis/solver_internals.rst
@@ -67,7 +67,7 @@ In the dump, the letters have the following meaning:
 - i: invalid symbol, returned when no valid symbol can be found.
 
 
-Stay contraints emulation
+Stay constraints emulation
 -------------------------
 
 One feature of Cassowary that Kiwi abandoned is the notion of stay

--- a/docs/source/use_cases/enaml.rst
+++ b/docs/source/use_cases/enaml.rst
@@ -59,7 +59,7 @@ quite painful to write by hand.
 
 To make constraints definition easier, Enaml relies on helpers function and
 classes. In the following, we will focus on how horizontal and vertical boxes
-constraints are handled, by studing the following example in details:
+constraints are handled, by studying the following example in details:
 
 .. image:: enaml_hbox.svg
 


### PR DESCRIPTION
Hello,

This tiny PR will fix : 

- 1 typo in `docs/source/basis/basic_systems.rst`
- 1 typo in `docs/source/basis/solver_internals.rst`
- 1 typo in `docs/source/use_cases/enaml.rst`



Best! :robot: