### PR TITLE
CI: fix building wheels on GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           KIWI_DISABLE_FH4: 1
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
-         if: matrix.python != 'cp37' & matrix.python != 'cp38'
+        if: matrix.python != 'cp37' && matrix.python != 'cp38'
         env:
           CIBW_BUILD: "cp39-* cp310-* pp37-*"
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64


### PR DESCRIPTION
We build CPython 3.7, 3.8, 3.9, 3.10 and Pypy 3.7 on Linux, Mac and Windows. For Mac we build ARM and universal wheels (which are however not tested) and on linux we build aarch64, s390x and ppc64le using emulation. 

Wheels up to Python 3.8 uses manylinux1 and for Python 3.9 and 3.10 we use manylinux 2010. This decision is based on https://github.com/pypa/cibuildwheel/issues/792#issuecomment-896899899. The manual build https://github.com/nucleic/kiwi/actions/runs/1172082067 passed so I will merge and start publishing the wheels.