### PR TITLE
cis: remove redundant release jobs and split emulated jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,13 +58,13 @@ jobs:
             manylinux_version: manylinux1
           - os: ubuntu-latest
             archs: aarch64
-            manylinux_version: mnanylinux2010
+            manylinux_version: manylinux2010
           - os: ubuntu-latest
             archs: ppc64le
-            manylinux_version: mnanylinux2010
+            manylinux_version: manylinux2010
           - os: ubuntu-latest
             archs: s390x
-            manylinux_version: mnanylinux2010
+            manylinux_version: manylinux2010
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           path: dist/*
 
   build_wheels:
-    name: Build wheels on ${{ matrix.os }} for ${{ matrix.archs }} and Python ${{ matrix.python }}+
+    name: Build wheels on ${{ matrix.os }} for ${{ matrix.archs }} using ${{ matrix.manylinux_version }}+
     runs-on: ${{ matrix.os }}
     env:
       BUILD_COMMIT: main
@@ -44,27 +44,27 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         # We build separately 3.7 and 3.8 using manylinux1
-        manylinux_version: [manylinux1, mnanylinux2010]
+        manylinux_version: [manylinux1, manylinux2010]
         archs: [auto]
         include:
           - os: ubuntu-latest
             archs: aarch64
-            py_version: cp37
+            manylinux_version: manylinux1
           - os: ubuntu-latest
             archs: ppc64le
-            py_version: cp37
+            manylinux_version: manylinux1
           - os: ubuntu-latest
             archs: s390x
-            py_version: cp37
+            manylinux_version: manylinux1
           - os: ubuntu-latest
             archs: aarch64
-            py_version: cp39
+            manylinux_version: mnanylinux2010
           - os: ubuntu-latest
             archs: ppc64le
-            py_version: cp39
+            manylinux_version: mnanylinux2010
           - os: ubuntu-latest
             archs: s390x
-            py_version: cp39
+            manylinux_version: mnanylinux2010
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
         with:
           python-version: '3.9'
       - name: Set up QEMU
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.archs != 'auto'
         uses: docker/setup-qemu-action@v1
         with:
           platforms: all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # We build separately 3.7+ and 3.9+ since 3.7+ we use manylinux1 for those
-        py_version: [cp37, cp39]
+        # We build separately 3.7 and 3.8 using manylinux1
+        manylinux_version: [manylinux1, mnanylinux2010]
         archs: [auto]
         include:
           - os: ubuntu-latest
@@ -79,12 +79,10 @@ jobs:
           platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
-        if: matrix.python == 'cp37'
+        if: matrix.manylinux_version == 'manylinux1'
         env:
           CIBW_BUILD: "cp37-* cp38-*"
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
-          # configure cibuildwheel to build native archs ('auto'), and some
-          # emulated ones
           CIBW_ARCHS_LINUX: ${{ matrix.archs }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
@@ -94,12 +92,10 @@ jobs:
           KIWI_DISABLE_FH4: 1
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
-        if: matrix.python == 'cp39'
+        if: matrix.manylinux_version == 'manylinux2010'
         env:
           CIBW_BUILD: "cp39-* cp310-* pp37-*"
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
-          # configure cibuildwheel to build native archs ('auto'), and some
-          # emulated ones
           CIBW_ARCHS_LINUX: ${{ matrix.archs }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
           CIBW_MANYLINUX_I686_IMAGE: manylinux2010

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,35 @@ jobs:
           path: dist/*
 
   build_wheels:
-    name: Build wheels on ${{ matrix.os }} for Python ${{ matrix.python }}
+    name: Build wheels on ${{ matrix.os }} for ${{ matrix.archs }} and Python ${{ matrix.python }}+
     runs-on: ${{ matrix.os }}
     env:
       BUILD_COMMIT: main
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: [cp37, cp38, cp39, cp310, pp3.7]
+        # We build separately 3.7+ and 3.9+ since 3.7+ we use manylinux1 for those
+        py_version: [cp37, cp39]
+        archs: [auto]
+        include:
+          - os: ubuntu-latest
+            archs: aarch64
+            py_version: cp37
+          - os: ubuntu-latest
+            archs: ppc64le
+            py_version: cp37
+          - os: ubuntu-latest
+            archs: s390x
+            py_version: cp37
+          - os: ubuntu-latest
+            archs: aarch64
+            py_version: cp39
+          - os: ubuntu-latest
+            archs: ppc64le
+            py_version: cp39
+          - os: ubuntu-latest
+            archs: s390x
+            py_version: cp39
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -58,13 +79,13 @@ jobs:
           platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
-        if: matrix.python == 'cp37' || matrix.python == 'cp38'
+        if: matrix.python == 'cp37'
         env:
-          CIBW_BUILD: ${{ matrix.python }}-*
+          CIBW_BUILD: "cp37-* cp38-*"
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
-          CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
+          CIBW_ARCHS_LINUX: ${{ matrix.archs }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
           CIBW_TEST_REQUIRES: pytest
@@ -73,13 +94,13 @@ jobs:
           KIWI_DISABLE_FH4: 1
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
-        if: matrix.python != 'cp37' && matrix.python != 'cp38'
+        if: matrix.python == 'cp39'
         env:
           CIBW_BUILD: "cp39-* cp310-* pp37-*"
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
-          CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
+          CIBW_ARCHS_LINUX: ${{ matrix.archs }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
           CIBW_MANYLINUX_I686_IMAGE: manylinux2010
           CIBW_TEST_REQUIRES: pytest


### PR DESCRIPTION
Cibuildwheel can handle multiple python version in a single job so use this ability and split emulated jobs which are slow in a job per architecture.