### PR TITLE
Include cstdlib in constraint.h

### DIFF
--- a/kiwi/constraint.h
+++ b/kiwi/constraint.h
@@ -6,6 +6,7 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 #pragma once
+#include <cstdlib>
 #include <map>
 #include <vector>
 #include "expression.h"

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -1,6 +1,10 @@
 Kiwi Release Notes
 ==================
 
+Wrappers 1.4.1 | Solver 1.4.1 | unreleased
+------------------------------------------
+- add missing include PR #129
+
 Wrappers 1.4.0 | Solver 1.4.0 | 14/03/2021
 ------------------------------------------
 - make installation PEP517 compliant PR #125


### PR DESCRIPTION
`std::abort` is not guaranteed to be available without this include, and this caused the build to fail on some platforms.