### PR TITLE
Add the missing version field to pyproject.toml 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@
 
 [project]
 name = "kiwisolver"
+version = "1.4.1"
 description = "A fast implementation of the Cassowary constraint solver"
 readme = "README.rst"
 requires-python = ">=3.7"

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,11 @@ except ImportError as e:
         "Installing through pip as recommended ensure one never hits this issue."
     ) from e
 
-# Before releasing the version needs to be updated in kiwi/version.h, if the changes
-# are not limited to the solver.
+# Before releasing:
+# 1) The version needs to be updated in kiwi/version.h, if the changes
+#    are not limited to the solver.
+#
+# 2) Make sure the version field in pyproject.toml is updated to the new version tag
 
 # Use the env var KIWI_DISABLE_FH4 to disable linking against VCRUNTIME140_1.dll
 


### PR DESCRIPTION
It is a required field, cf: `https://python-poetry.org/docs/pyproject/` 