### PR TITLE
Add PyPy 3.10 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
             pip install delvewheel
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
             delvewheel repair -w {dest_dir} {wheel}
-          CIBW_BUILD: "cp312-* cp311-* pp39-*"
+          CIBW_BUILD: "cp312-* cp311-* pp39-* pp310-*"
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           CIBW_ARCHS_LINUX: ${{ matrix.archs }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,12 @@
     changelog = "https://github.com/nucleic/kiwi/blob/main/releasenotes.rst"
 
 [build-system]
-  requires = ["setuptools>=61.2", "wheel", "setuptools_scm[toml]>=3.4.3", "cppy>=1.2.0"]
+  requires = [
+    "setuptools>=61.2; implementation_name == 'cpython'",
+    "setuptools>=61.2,!=72.2.0; implementation_name != 'cpython'",
+    "setuptools_scm[toml]>=3.4.3",
+    "cppy>=1.2.0"
+  ]
   build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
Also, avoid `setuptools` 72.2.0 on PyPy, because it is broken due to https://github.com/pypa/distutils/issues/283.