### PR TITLE
MNT: Enable free threading support for Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
         exclude:
           - python-version: '3.8'
             os: macos-latest
@@ -86,16 +86,31 @@ jobs:
             os: macos-latest
           - python-version: 'pypy-3.8'
             os: macos-latest
+        include:
+          # Only test free threading on ubuntu latest due to setup-python availability
+          - os: ubuntu-latest
+            python-version: '3.13t'
     steps:
       - uses: actions/checkout@v4
       - name: Get history and tags for SCM versioning to work
         run: |
           git fetch --prune --unshallow
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+  
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
+        if: matrix.python-version != '3.13t'
         with:
           python-version: ${{ matrix.python-version }}
+
+      # Remove once the main setup-python adds python free threading
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: deadsnakes/action@6c8b9b82fe0b4344f4b98f2775fcc395df45e494  # v3.1.0
+        if: matrix.python-version == '3.13t'
+        with:
+          python-version: '3.13'
+          nogil: true
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,8 @@ jobs:
             setup-args="-Db_vscrt=mt"
             setup-args="-Dcpp_link_args=['ucrt.lib','vcruntime.lib','/nodefaultlib:libucrt.lib','/nodefaultlib:libvcruntime.lib']"
           CIBW_BUILD: "cp311-* cp312-* cp313-* pp39-* pp310-*"
+          # Enable free-threaded support
+          CIBW_FREE_THREADED_SUPPORT: 1
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           CIBW_ARCHS_LINUX: ${{ matrix.archs }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
@@ -176,6 +178,8 @@ jobs:
             setup-args="-Db_vscrt=mt"
             setup-args="-Dcpp_link_args=['ucrt.lib','vcruntime.lib','/nodefaultlib:libucrt.lib','/nodefaultlib:libvcruntime.lib']"
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+          # Enable free-threaded support
+          CIBW_FREE_THREADED_SUPPORT: 1
           CIBW_ARCHS_WINDOWS: ${{ matrix.archs }}
           # It is not yet possible to run ARM64 tests, only cross-compile them.
           CIBW_TEST_SKIP: "*-win_arm64"

--- a/py/src/kiwisolver.cpp
+++ b/py/src/kiwisolver.cpp
@@ -162,6 +162,9 @@ kiwisolver_methods[] = {
 
 PyModuleDef_Slot kiwisolver_slots[] = {
     {Py_mod_exec, reinterpret_cast<void*>( kiwi_modexec ) },
+#ifdef Py_GIL_DISABLED
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
     {0, NULL}
 };
 


### PR DESCRIPTION
This declares the module as supporting nogil Python releases. I have tested it locally and it works as expected. Without this I get a warning that kiwisolver doesn't support the nogil free threading, without this it runs as expected and passes the tests.

Some links for information on what I am updating here.

Update to the module definition:
https://py-free-threading.github.io/porting/#__tabbed_1_1

CI testing:
Added installation from the deadsnakes setup-python version, which I think will only work on the ubuntu runner:
https://py-free-threading.github.io/ci/

cibuildwheel support to build the free threaded wheels:
https://cibuildwheel.pypa.io/en/stable/options/#free-threaded-support