### PR TITLE
Include Python.h-including headers first

### DIFF
--- a/py/src/constraint.cpp
+++ b/py/src/constraint.cpp
@@ -5,9 +5,9 @@
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
+#include <cppy/cppy.h>
 #include <algorithm>
 #include <sstream>
-#include <cppy/cppy.h>
 #include <kiwi/kiwi.h>
 #include "types.h"
 #include "util.h"

--- a/py/src/expression.cpp
+++ b/py/src/expression.cpp
@@ -5,8 +5,8 @@
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
-#include <sstream>
 #include <cppy/cppy.h>
+#include <sstream>
 #include "symbolics.h"
 #include "types.h"
 #include "util.h"

--- a/py/src/kiwisolver.cpp
+++ b/py/src/kiwisolver.cpp
@@ -5,8 +5,8 @@
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
-#include <mutex>
 #include <cppy/cppy.h>
+#include <mutex>
 #include <kiwi/kiwi.h>
 #include "types.h"
 #include "version.h"

--- a/py/src/term.cpp
+++ b/py/src/term.cpp
@@ -5,8 +5,8 @@
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
-#include <sstream>
 #include <cppy/cppy.h>
+#include <sstream>
 #include "symbolics.h"
 #include "types.h"
 #include "util.h"

--- a/py/src/util.h
+++ b/py/src/util.h
@@ -6,10 +6,10 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 #pragma once
+#include <cppy/cppy.h>
 #include <map>
 #include <mutex>
 #include <string>
-#include <cppy/cppy.h>
 #include <kiwi/kiwi.h>
 #include "types.h"
 

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -1,6 +1,10 @@
 Kiwi Release Notes
 ==================
 
+Wrappers 1.4.9 | Solver 1.4.2 | ??/??/202?
+------------------------------------------
+- Include Python.h, or headers including Python.h, before system headers
+
 Wrappers 1.4.8 | Solver 1.4.2 | 24/12/2024
 ------------------------------------------
 - drop support for Python 3.8 and 3.9 PR #189


### PR DESCRIPTION
Python.h must be included before any system headers:
https://docs.python.org/3/extending/extending.html#a-simple-example

This blocks compilation on my platform, because the redefinitions mean some symbols are defined without their dependencies: in particular, `sys/time.h` tries to declare `bintime_mul(struct bintime *_bt, u_int _x` because `_BSD_SOURCE` is defined then, but fails because `_BSD_SOURCE` was not defined when processing `cstdint` or whichever header defines `u_int`.