### PR TITLE
Add iOS build configuration.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Build wheels
         if: matrix.target == 'manylinux2014'
         env:
-          CIBW_BUILD: "cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-* pp310-* pp311-*"
+          CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-* cp314t-* pp310-* pp311-*"
           CIBW_SKIP: "cp313t-win*"
           CIBW_ENABLE: pypy cpython-prerelease pypy-eol
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
@@ -132,7 +132,7 @@ jobs:
       - name: Build wheels
         if: matrix.target == 'manylinux_2_39'
         env:
-          CIBW_BUILD: "cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-* pp310-* pp311-*"
+          CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-* cp314t-* pp310-* pp311-*"
           CIBW_SKIP: "cp313t-win*"
           CIBW_ENABLE: pypy cpython-prerelease pypy-eol
           CIBW_ARCHS_LINUX: ${{ matrix.archs }}
@@ -141,7 +141,7 @@ jobs:
       - name: Build wheels
         if: runner.os == 'Windows' && matrix.archs == 'ARM64'
         env:
-          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-*"
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
           CIBW_ENABLE: cpython-prerelease
           CIBW_ARCHS_WINDOWS: ${{ matrix.archs }}
           # It is not yet possible to run ARM64 tests, only cross-compile them.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,48 +40,51 @@ jobs:
           path: dist/*
 
   build_wheels:
-    name: Build wheels on ${{ matrix.os }} for ${{ matrix.archs }} using ${{ matrix.manylinux_version }}+
+    name: Build wheels on ${{ matrix.os }} for ${{ matrix.archs }} using ${{ matrix.target }}+
     runs-on: ${{ matrix.os }}
     env:
       BUILD_COMMIT: main
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        manylinux_version: [manylinux2010, manylinux2014]
+        target: [manylinux2010, manylinux2014]
         archs: [auto]
         include:
           - os: ubuntu-latest
             archs: aarch64
-            manylinux_version: manylinux2010
+            target: manylinux2010
           - os: ubuntu-latest
             archs: ppc64le
-            manylinux_version: manylinux2010
+            target: manylinux2010
           - os: ubuntu-latest
             archs: s390x
-            manylinux_version: manylinux2010
+            target: manylinux2010
           - os: ubuntu-latest
             archs: aarch64
-            manylinux_version: manylinux2014
+            target: manylinux2014
           - os: ubuntu-latest
             archs: ppc64le
-            manylinux_version: manylinux2014
+            target: manylinux2014
           - os: ubuntu-latest
             archs: riscv64
-            manylinux_version: manylinux_2_39
+            target: manylinux_2_39
           - os: ubuntu-latest
             archs: s390x
-            manylinux_version: manylinux2014
+            target: manylinux2014
           - os: windows-latest
             archs: ARM64
           - os: ubuntu-latest
             archs: auto
-            manylinux_version: graalpy
+            target: graalpy
           - os: windows-latest
             archs: auto64
-            manylinux_version: graalpy
+            target: graalpy
           - os: macos-latest
             archs: auto
-            manylinux_version: graalpy
+            target: graalpy
+          - os: macos-latest
+            archs: all
+            target: ios
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -101,9 +104,9 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
-          python -m pip install wheel cibuildwheel==3.3.0
+          python -m pip install wheel cibuildwheel==4.1.0
       - name: Build wheels
-        if: matrix.manylinux_version == 'manylinux2010'
+        if: matrix.target == 'manylinux2010'
         env:
           CIBW_BUILD: "cp310-*"
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
@@ -111,12 +114,10 @@ jobs:
           CIBW_ARCHS_WINDOWS: auto64
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: python -m pytest {package}/py/tests -v
         run: |
           python -m cibuildwheel . --output-dir dist
       - name: Build wheels
-        if: matrix.manylinux_version == 'manylinux2014'
+        if: matrix.target == 'manylinux2014'
         env:
           CIBW_BUILD: "cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-* pp310-* pp311-*"
           CIBW_SKIP: "cp313t-win*"
@@ -126,19 +127,15 @@ jobs:
           CIBW_ARCHS_WINDOWS: auto64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: python -m pytest {package}/py/tests -v
         run: |
           python -m cibuildwheel . --output-dir dist
       - name: Build wheels
-        if: matrix.manylinux_version == 'manylinux_2_39'
+        if: matrix.target == 'manylinux_2_39'
         env:
           CIBW_BUILD: "cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-* pp310-* pp311-*"
           CIBW_SKIP: "cp313t-win*"
           CIBW_ENABLE: cpython-freethreading pypy cpython-prerelease pypy-eol
           CIBW_ARCHS_LINUX: ${{ matrix.archs }}
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: python -m pytest {package}/py/tests -v
         run: |
           python -m cibuildwheel . --output-dir dist
       - name: Build wheels
@@ -149,26 +146,29 @@ jobs:
           CIBW_ARCHS_WINDOWS: ${{ matrix.archs }}
           # It is not yet possible to run ARM64 tests, only cross-compile them.
           CIBW_TEST_SKIP: "*-win_arm64"
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: python -m pytest {package}/py/tests -v
         run: |
           python -m cibuildwheel . --output-dir dist
       - name: Build wheels
-        if: matrix.manylinux_version == 'graalpy'
+        if: matrix.target == 'graalpy'
         env:
           CIBW_BUILD: "gp312_250-*"
           CIBW_ENABLE: graalpy
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_WINDOWS: auto64
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: python -m pytest {package}/py/tests -v
+        run: |
+          python -m cibuildwheel . --output-dir dist
+      - name: Build wheels
+        if: matrix.target == 'ios'
+        env:
+          CIBW_PLATFORM: ios
+          CIBW_ARCHS: all
         run: |
           python -m cibuildwheel . --output-dir dist
       - name: Store artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: cibw-wheels-${{ runner.os }}-${{ matrix.manylinux_version }}-${{ matrix.archs }}
+          name: cibw-wheels-${{ runner.os }}-${{ matrix.target }}-${{ matrix.archs }}
           path: dist/*.whl
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
     env:
       BUILD_COMMIT: main
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         target: [manylinux2010, manylinux2014]
@@ -153,7 +154,7 @@ jobs:
         env:
           CIBW_BUILD: "gp312_250-*"
           CIBW_ENABLE: graalpy
-          CIBW_ARCHS_MACOS: x86_64 universal2 arm64
+          CIBW_ARCHS_MACOS: auto
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_WINDOWS: auto64
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         env:
           CIBW_BUILD: "cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-* pp310-* pp311-*"
           CIBW_SKIP: "cp313t-win*"
-          CIBW_ENABLE: cpython-freethreading pypy cpython-prerelease pypy-eol
+          CIBW_ENABLE: pypy cpython-prerelease pypy-eol
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           CIBW_ARCHS_LINUX: ${{ matrix.archs }}
           CIBW_ARCHS_WINDOWS: auto64
@@ -134,7 +134,7 @@ jobs:
         env:
           CIBW_BUILD: "cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-* pp310-* pp311-*"
           CIBW_SKIP: "cp313t-win*"
-          CIBW_ENABLE: cpython-freethreading pypy cpython-prerelease pypy-eol
+          CIBW_ENABLE: pypy cpython-prerelease pypy-eol
           CIBW_ARCHS_LINUX: ${{ matrix.archs }}
         run: |
           python -m cibuildwheel . --output-dir dist
@@ -142,7 +142,7 @@ jobs:
         if: runner.os == 'Windows' && matrix.archs == 'ARM64'
         env:
           CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-*"
-          CIBW_ENABLE: cpython-freethreading cpython-prerelease
+          CIBW_ENABLE: cpython-prerelease
           CIBW_ARCHS_WINDOWS: ${{ matrix.archs }}
           # It is not yet possible to run ARM64 tests, only cross-compile them.
           CIBW_TEST_SKIP: "*-win_arm64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
         if: matrix.target == 'ios'
         env:
           CIBW_PLATFORM: ios
+          CIBW_ENABLE: cpython-prerelease
           CIBW_ARCHS: all
         run: |
           python -m cibuildwheel . --output-dir dist

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ py/src/version.h
 benchmarks/run_bench
 build/
 dist/
+wheelhouse/
 kiwisolver.egg-info/
 .eggs
 .vscode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@
 
 [tool.cibuildwheel]
   test-requires = ["pytest"]
-  test-command = "python -m pytest {package}py/tests -v"
+  test-command = "python -m pytest {package}/py/tests -v"
 
 [tool.cibuildwheel.ios]
   xbuild-tools = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,12 @@
 
 [tool.cibuildwheel]
   test-requires = ["pytest"]
-  test-command = "python -m pytest py/tests -v"
+  test-command = "python -m pytest {package}py/tests -v"
 
 [tool.cibuildwheel.ios]
   xbuild-tools = []
   test-sources = ["py/tests"]
+  test-command = "python -m pytest py/tests -vv"
 
 [tool.ruff]
   src = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,14 @@
 
 """
 
+[tool.cibuildwheel]
+  test-requires = ["pytest"]
+  test-command = "python -m pytest py/tests -v"
+
+[tool.cibuildwheel.ios]
+  xbuild-tools = []
+  test-sources = ["py/tests"]
+
 [tool.ruff]
   src = ["src"]
   line-length = 88


### PR DESCRIPTION
iOS is a Tier 3 supported platform on CPython 3.13+ (as a result of PEP 730). This PR refactors the cibuildwheel configuration so that common testing features are in a shared configuration in `pyproject.toml`, and adds the additional configuration items needed to configure iOS builds.

This will produce 3 wheels per CPython version:
* ARM64 device
* ARM64 simulator
* x86_64 simulator

It will run the test suite using the ARM64 simulator.