### PR TITLE
docs: add Sourcey C++ API reference

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,8 +14,9 @@ build:
   apt_packages:
     - doxygen
   jobs:
-    post_build:
+    pre_build:
       - doxygen Doxyfile.sourcey
+    post_build:
       - npx --yes sourcey@3.6.5 build --output "$READTHEDOCS_OUTPUT/html/cpp-api"
 
 # Build documentation in the docs/source directory with Sphinx

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,13 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.9"
+    nodejs: "20"
+  apt_packages:
+    - doxygen
+  jobs:
+    post_build:
+      - doxygen Doxyfile.sourcey
+      - npx --yes sourcey@3.6.5 build --output "$READTHEDOCS_OUTPUT/html/cpp-api"
 
 # Build documentation in the docs/source directory with Sphinx
 sphinx:

--- a/Doxyfile.sourcey
+++ b/Doxyfile.sourcey
@@ -1,0 +1,27 @@
+PROJECT_NAME           = "Kiwi C++ API"
+OUTPUT_DIRECTORY       = build/doxygen-public
+INPUT                  = kiwi/constraint.h \
+                         kiwi/errors.h \
+                         kiwi/expression.h \
+                         kiwi/solver.h \
+                         kiwi/strength.h \
+                         kiwi/symbolics.h \
+                         kiwi/term.h \
+                         kiwi/variable.h \
+                         kiwi/version.h
+FILE_PATTERNS           = *.h
+RECURSIVE               = YES
+GENERATE_HTML           = NO
+GENERATE_LATEX          = NO
+GENERATE_XML            = YES
+XML_OUTPUT              = xml
+EXTRACT_ALL             = YES
+EXTRACT_PRIVATE         = NO
+EXTRACT_STATIC          = YES
+FULL_PATH_NAMES         = NO
+STRIP_FROM_PATH         = .
+SOURCE_BROWSER          = YES
+REFERENCED_BY_RELATION  = YES
+REFERENCES_RELATION     = YES
+QUIET                   = YES
+WARN_IF_UNDOCUMENTED    = NO

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx>=4
 sphinx-rtd-theme>=1
 sphinx-tabs
+breathe

--- a/docs/source/api/cpp.rst
+++ b/docs/source/api/cpp.rst
@@ -1,4 +1,8 @@
 Kiwisolver C++ API
 ==================
 
-Under construction
+.. doxygenindex::
+   :project: kiwi
+
+The `searchable Sourcey reference <https://kiwisolver.readthedocs.io/en/latest/cpp-api/>`_
+is generated from the same pinned Doxygen XML.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+from pathlib import Path
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -54,7 +54,14 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "sphinx_tabs.tabs",
+    "breathe",
 ]
+
+breathe_projects = {
+    "kiwi": str(Path(__file__).parents[2] / "build" / "doxygen-public" / "xml")
+}
+breathe_default_project = "kiwi"
+breathe_domain_by_extension = {"h": "cpp"}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,6 @@ In addition to the C++ solver, Kiwi ships with hand-rolled Python bindings.
    Use cases <use_cases/index.rst>
    Developer notes <developer_notes/index.rst>
    API Documentation <api/index.rst>
-   C++ API Reference <https://kiwisolver.readthedocs.io/en/latest/cpp-api/>
 
 Indices and tables
 ==================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ In addition to the C++ solver, Kiwi ships with hand-rolled Python bindings.
    Use cases <use_cases/index.rst>
    Developer notes <developer_notes/index.rst>
    API Documentation <api/index.rst>
+   C++ API Reference <https://kiwisolver.readthedocs.io/en/latest/cpp-api/>
 
 Indices and tables
 ==================

--- a/sourcey.config.ts
+++ b/sourcey.config.ts
@@ -1,0 +1,23 @@
+export default {
+  name: "Kiwi C++ API Reference",
+  siteUrl: "https://kiwisolver.readthedocs.io",
+  baseUrl: "/en/latest/cpp-api",
+  repo: "https://github.com/nucleic/kiwi",
+  editBranch: "main",
+  navigation: {
+    tabs: [
+      {
+        tab: "C++ API",
+        slug: "",
+        doxygen: {
+          xml: "./build/doxygen-public/xml",
+          language: "cpp",
+          groups: false,
+          index: "rich",
+          sourceUrl:
+            "https://github.com/nucleic/kiwi/blob/e8acf1e0eb8c21c6193d7dd621e3f03b7277f122/{path}#L{line}",
+        },
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- generate a source-linked C++ API reference from Kiwi's public headers with Doxygen and Sourcey 3.6.5
- publish the generated reference under the existing Read the Docs site at `/cpp-api/`
- link the reference from the main documentation navigation

## Verification
- `doxygen Doxyfile.sourcey`
- `sourcey build --output sourcey-preview-113b` (18 pages generated)
- `python -m sphinx -W -b html docs/source build/sphinx-113`
- durable preview: https://zdfgu113.github.io/kiwi/

The Sourcey config pins source links to commit `e8acf1e0eb8c21c6193d7dd621e3f03b7277f122`. Generated HTML is not committed; Read the Docs builds it after the Sphinx build.

Closes #60.

AI assistance disclosure: OpenAI Codex assisted with generation, configuration, and testing; the resulting files and public output were reviewed and verified locally.