### PR TITLE
Build wheels for WASM/Pyodide also

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,17 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.13t', '3.14', '3.14t', '3.15-dev', '3.15t-dev', 'pypy-3.10', 'pypy-3.11', 'graalpy-25.0']
+        platform: ['native']
+        include:
+          - os: 'ubuntu-latest'
+            python-version: '3.13'
+            platform: 'pyodide'
+          - os: 'ubuntu-latest'
+            python-version: '3.14'
+            platform: 'pyodide'
+          - os: 'ubuntu-latest'
+            python-version: '3.15-dev'
+            platform: 'pyodide'
     steps:
       - uses: actions/checkout@v7
       - name: Get history and tags for SCM versioning to work
@@ -123,25 +134,48 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-node@v4
+        if: matrix.platform == 'pyodide'
+        with:
+          node-version: "24"
+      - name: Install pyodide-build
+        if: matrix.platform == 'pyodide'
+        run: pip install pyodide-build
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
       - name: Install project
+        if: matrix.platform == 'native'
         env:
           CPPFLAGS: --coverage
         run: |
           pip install .
+      - name: Build wheel
+        if: matrix.platform == 'pyodide'
+        run: pyodide build .
       - name: Test with pytest
+        shell: bash
         run: |
+          if [[ "${{ matrix.platform }}" == 'pyodide' ]]; then
+            pyodide venv .venv-pyodide
+            source .venv-pyodide/bin/activate
+            pip install dist/*.whl
+          fi
           pip install pytest
           python -X dev -m pytest py -W error
       - name: Generate C++ coverage reports
-        if: (github.event_name != 'schedule' && matrix.os != 'windows-latest')
+        if: >-
+          (github.event_name != 'schedule'
+          && matrix.os != 'windows-latest'
+          && matrix.platform == 'native')
         run: |
           bash -c "find . -type f -name '*.gcno' -exec gcov -pb --all-blocks {} +" || true
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
-        if: (github.event_name != 'schedule' && matrix.os != 'windows-latest')
+        if: >-
+          (github.event_name != 'schedule'
+          && matrix.os != 'windows-latest'
+          && matrix.platform == 'native')
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
           - os: macos-latest
             archs: all
             target: ios
+          - os: ubuntu-latest
+            archs: auto
+            target: pyodide
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -105,7 +108,7 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
-          python -m pip install wheel cibuildwheel==4.1.0
+          python -m pip install wheel cibuildwheel==4.2.0
       - name: Build wheels
         if: matrix.target == 'manylinux2010'
         env:
@@ -164,6 +167,13 @@ jobs:
         env:
           CIBW_PLATFORM: ios
           CIBW_ENABLE: cpython-prerelease
+          CIBW_ARCHS: all
+        run: |
+          python -m cibuildwheel . --output-dir dist
+      - name: Build wheels
+        if: matrix.target == 'pyodide'
+        env:
+          CIBW_PLATFORM: pyodide
           CIBW_ARCHS: all
         run: |
           python -m cibuildwheel . --output-dir dist

--- a/py/src/constraint.cpp
+++ b/py/src/constraint.cpp
@@ -53,9 +53,11 @@ Constraint_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     return pycn.release();
 }
 
-void Constraint_clear(Constraint *self)
+int
+Constraint_clear(Constraint *self)
 {
     Py_CLEAR(self->expression);
+    return 0;
 }
 
 int Constraint_traverse(Constraint *self, visitproc visit, void *arg)

--- a/py/src/expression.cpp
+++ b/py/src/expression.cpp
@@ -51,10 +51,11 @@ Expression_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
 }
 
 
-void
+int
 Expression_clear( Expression* self )
 {
     Py_CLEAR( self->terms );
+    return 0;
 }
 
 

--- a/py/src/term.cpp
+++ b/py/src/term.cpp
@@ -45,10 +45,11 @@ Term_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
 }
 
 
-void
+int
 Term_clear( Term* self )
 {
 	Py_CLEAR( self->variable );
+	return 0;
 }
 
 

--- a/py/src/variable.cpp
+++ b/py/src/variable.cpp
@@ -61,10 +61,11 @@ Variable_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
 }
 
 
-void
+int
 Variable_clear( Variable* self )
 {
 	Py_CLEAR( self->context );
+	return 0;
 }
 
 


### PR DESCRIPTION
This also bumps cibuildwheel to 4.2.0 to enable the Pyodide 3.15 wheels.